### PR TITLE
Added pepper in UsernamePasswordAuthenticator to verify passwords

### DIFF
--- a/src/Opulence/Authentication/Credentials/Authenticators/UsernamePasswordAuthenticator.php
+++ b/src/Opulence/Authentication/Credentials/Authenticators/UsernamePasswordAuthenticator.php
@@ -26,15 +26,19 @@ class UsernamePasswordAuthenticator implements IAuthenticator
     protected $userRepository = null;
     /** @var IRoleRepository The role repository */
     protected $roleRepository = null;
+    /** @var string The pepper used for hashing */
+    protected $pepper = "";
 
     /**
      * @param IUserRepository $userRepository The user repository
      * @param IRoleRepository $roleRepository The role repository
+     * @param string $pepper The pepper used for hashing
      */
-    public function __construct(IUserRepository $userRepository, IRoleRepository $roleRepository)
+    public function __construct(IUserRepository $userRepository, IRoleRepository $roleRepository, string $pepper = "")
     {
         $this->userRepository = $userRepository;
         $this->roleRepository = $roleRepository;
+        $this->pepper = $pepper;
     }
 
     /**
@@ -59,7 +63,7 @@ class UsernamePasswordAuthenticator implements IAuthenticator
             return false;
         }
 
-        if (!\password_verify($password, $user->getHashedPassword())) {
+        if (!\password_verify($password.$this->pepper, $user->getHashedPassword())) {
             $error = AuthenticatorErrorTypes::CREDENTIAL_INCORRECT;
 
             return false;

--- a/tests/src/Opulence/Authentication/Credentials/Authenticators/UsernamePasswordAuthenticatorTest.php
+++ b/tests/src/Opulence/Authentication/Credentials/Authenticators/UsernamePasswordAuthenticatorTest.php
@@ -35,7 +35,7 @@ class UsernamePasswordAuthenticatorTest extends \PHPUnit\Framework\TestCase
     {
         $this->userRepository = $this->createMock(IUserRepository::class);
         $this->roleRepository = $this->createMock(IRoleRepository::class);
-        $this->authenticator = new UsernamePasswordAuthenticator($this->userRepository, $this->roleRepository);
+        $this->authenticator = new UsernamePasswordAuthenticator($this->userRepository, $this->roleRepository, "pepper");
         $this->credential = $this->createMock(ICredential::class);
     }
 
@@ -58,7 +58,7 @@ class UsernamePasswordAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $user = $this->createMock(IUser::class);
         $user->expects($this->once())
             ->method("getHashedPassword")
-            ->willReturn(password_hash("password", PASSWORD_BCRYPT));
+            ->willReturn(password_hash("password"."pepper", PASSWORD_BCRYPT));
         $user->expects($this->once())
             ->method("getId")
             ->willReturn("userId");


### PR DESCRIPTION
Previously if the password was hashed with the included Hasher class (that supports it) using a pepper the UsernamePasswordAuthenticator would systematically fail since It didn't support peppering a password. Now it does.