### PR TITLE
Optimize session GC

### DIFF
--- a/src/Opulence/Sessions/Handlers/FileSessionHandler.php
+++ b/src/Opulence/Sessions/Handlers/FileSessionHandler.php
@@ -51,10 +51,10 @@ class FileSessionHandler extends SessionHandler
     {
         $sessionFiles = glob($this->path . "/*");
 
+        $limit = time() - $maxLifetime;
         foreach ($sessionFiles as $sessionFile) {
-            $lastModified = DateTime::createFromFormat("U", filemtime($sessionFile));
-
-            if (new DateTime("$maxLifetime seconds ago") > $lastModified) {
+            $lastModified = filemtime($sessionFile);
+            if ($lastModified < $limit) {
                 @unlink($sessionFile);
             }
         }


### PR DESCRIPTION
Constructing two datetime objects for a couple ten thousand session
files is extremely expensive, to the point where it dominates
execution time.

Use a simple unix timestamp comparison instead.