### PR TITLE
ensure ENV_NAME and Environment::name are never out of sync

### DIFF
--- a/src/Opulence/Environments/Environment.php
+++ b/src/Opulence/Environments/Environment.php
@@ -22,8 +22,7 @@ class Environment
     /** The development environment */
     const DEVELOPMENT = "development";
 
-    /** @var string The name of the environment */
-    private $name = "";
+    const ENV_NAME_KEY = "ENV_NAME";
 
     /**
      * @param string $name The name of the environment
@@ -38,7 +37,7 @@ class Environment
      */
     public function getName() : string
     {
-        return $this->name;
+        return $this->getVar(Environment::ENV_NAME_KEY);
     }
 
     /**
@@ -80,7 +79,7 @@ class Environment
      */
     public function setName(string $name)
     {
-        $this->name = $name;
+        $this->setVar(Environment::ENV_NAME_KEY, $name);
     }
 
     /**

--- a/tests/src/Opulence/Environments/EnvironmentTest.php
+++ b/tests/src/Opulence/Environments/EnvironmentTest.php
@@ -120,4 +120,10 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $_SERVER["bar"] = "baz";
         $this->assertEquals("baz", $this->environment->getVar("bar"));
     }
+
+    public function testEnvironmentNameAndEnvNameAreInSync()
+    {
+        $this->environment->setVar(Environment::ENV_NAME_KEY, "bar");
+        $this->assertEquals("bar", $this->environment->getName());
+    }
 }


### PR DESCRIPTION
The Opulence starter project sets ENV_NAME as an environment variable, and that environment variable is then used to set the Environmnet::name. If the ENV_NAME variable is changed, or the Environment::name member is changed, the two values would no longer have been equal.