### PR TITLE
Refactoring ioc container

### DIFF
--- a/src/Opulence/Ioc/ClassBinding.php
+++ b/src/Opulence/Ioc/ClassBinding.php
@@ -11,21 +11,27 @@ namespace Opulence\Ioc;
 /**
  * Defines a class binding
  */
-class ClassBinding
+class ClassBinding implements IBinding
 {
     /** @var string The name of the concrete class */
     private $concreteClass = "";
     /** @var array The list of constructor primitives */
     private $constructorPrimitives = [];
+    /**
+     * @var bool
+     */
+    private $resolveAsSingleton;
 
     /**
-     * @param string $concreteClass The name of the concrete class
-     * @param array $constructorPrimitives The list of constructor primitives
+     * @param string $concreteClass         The name of the concrete class
+     * @param array  $constructorPrimitives The list of constructor primitives
+     * @param bool   $resolveAsSingleton
      */
-    public function __construct(string $concreteClass, array $constructorPrimitives = [])
+    public function __construct(string $concreteClass, array $constructorPrimitives = [], bool $resolveAsSingleton)
     {
         $this->concreteClass = $concreteClass;
         $this->constructorPrimitives = $constructorPrimitives;
+        $this->resolveAsSingleton = $resolveAsSingleton;
     }
 
     /**
@@ -42,5 +48,13 @@ class ClassBinding
     public function getConstructorPrimitives() : array
     {
         return $this->constructorPrimitives;
+    }
+
+    /**
+     * @return bool
+     */
+    public function resolveAsSingleton() : bool
+    {
+        return $this->resolveAsSingleton;
     }
 }

--- a/src/Opulence/Ioc/ClassBinding.php
+++ b/src/Opulence/Ioc/ClassBinding.php
@@ -3,7 +3,7 @@
  * Opulence
  *
  * @link      https://www.opulencephp.com
- * @copyright Copyright (C) 2016 David Young
+ * @copyright Copyright (C) 2017 David Young
  * @license   https://github.com/opulencephp/Opulence/blob/master/LICENSE.md
  */
 namespace Opulence\Ioc;

--- a/src/Opulence/Ioc/ClassBinding.php
+++ b/src/Opulence/Ioc/ClassBinding.php
@@ -3,7 +3,7 @@
  * Opulence
  *
  * @link      https://www.opulencephp.com
- * @copyright Copyright (C) 2017 David Young
+ * @copyright Copyright (C) 2016 David Young
  * @license   https://github.com/opulencephp/Opulence/blob/master/LICENSE.md
  */
 namespace Opulence\Ioc;
@@ -17,10 +17,8 @@ class ClassBinding implements IBinding
     private $concreteClass = "";
     /** @var array The list of constructor primitives */
     private $constructorPrimitives = [];
-    /**
-     * @var bool
-     */
-    private $resolveAsSingleton;
+    /** @var bool Whether or not the class should be resolved as a singleton */
+    private $resolveAsSingleton = false;
 
     /**
      * @param string $concreteClass         The name of the concrete class

--- a/src/Opulence/Ioc/Container.php
+++ b/src/Opulence/Ioc/Container.php
@@ -81,7 +81,7 @@ class Container implements IContainer
     public function callClosure(callable $closure, array $primitives = [])
     {
         $unresolvedParameters = (new ReflectionFunction($closure))->getParameters();
-        $resolvedParameters   = $this->resolveParameters(null, $unresolvedParameters, $primitives);
+        $resolvedParameters = $this->resolveParameters(null, $unresolvedParameters, $primitives);
 
         return $closure(...$resolvedParameters);
     }
@@ -100,8 +100,8 @@ class Container implements IContainer
         }
 
         $unresolvedParameters = (new ReflectionMethod($instance, $methodName))->getParameters();
-        $className            = is_string($instance) ? $instance : get_class($instance);
-        $resolvedParameters   = $this->resolveParameters($className, $unresolvedParameters, $primitives);
+        $className = is_string($instance) ? $instance : get_class($instance);
+        $resolvedParameters = $this->resolveParameters($className, $unresolvedParameters, $primitives);
 
         return ([$instance, $methodName])(...$resolvedParameters);
     }
@@ -112,7 +112,7 @@ class Container implements IContainer
     public function for (string $targetClass, callable $callback)
     {
         $this->targetStack[] = $targetClass;
-        $result              = $callback($this);
+        $result = $callback($this);
         array_pop($this->targetStack);
 
         return $result;
@@ -295,9 +295,9 @@ class Container implements IContainer
     /**
      * Resolves a list of parameters for a function call
      *
-     * @param string|null           $class                The name of the class whose parameters we're resolving
+     * @param string|null $class The name of the class whose parameters we're resolving
      * @param ReflectionParameter[] $unresolvedParameters The list of unresolved parameters
-     * @param array                 $primitives           The list of primitive values
+     * @param array $primitives The list of primitive values
      * @return array The list of parameters with all the dependencies resolved
      * @throws IocException Thrown if there was an error resolving the parameters
      */
@@ -353,7 +353,7 @@ class Container implements IContainer
      * Resolves a primitive parameter
      *
      * @param ReflectionParameter $parameter  The primitive parameter to resolve
-     * @param array               $primitives The list of primitive values
+     * @param array $primitives The list of primitive values
      * @return mixed The resolved primitive
      * @throws IocException Thrown if there was a problem resolving the primitive
      */

--- a/src/Opulence/Ioc/FactoryBinding.php
+++ b/src/Opulence/Ioc/FactoryBinding.php
@@ -11,7 +11,7 @@ namespace Opulence\Ioc;
 /**
  * Defines a factory binding
  */
-class FactoryBinding
+class FactoryBinding implements IBinding
 {
     /** @var callable The factory */
     private $factory = null;

--- a/src/Opulence/Ioc/IBinding.php
+++ b/src/Opulence/Ioc/IBinding.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Opulence
+ *
+ * @link      https://www.opulencephp.com
+ * @copyright Copyright (C) 2016 David Young
+ * @license   https://github.com/opulencephp/Opulence/blob/master/LICENSE.md
+ */
+
+namespace Opulence\Ioc;
+
+
+interface IBinding
+{
+    public function resolveAsSingleton() : bool;
+}

--- a/src/Opulence/Ioc/IBinding.php
+++ b/src/Opulence/Ioc/IBinding.php
@@ -3,7 +3,7 @@
  * Opulence
  *
  * @link      https://www.opulencephp.com
- * @copyright Copyright (C) 2016 David Young
+ * @copyright Copyright (C) 2017 David Young
  * @license   https://github.com/opulencephp/Opulence/blob/master/LICENSE.md
  */
 

--- a/tests/src/Opulence/Ioc/ClassBindingTest.php
+++ b/tests/src/Opulence/Ioc/ClassBindingTest.php
@@ -21,7 +21,7 @@ class ClassBindingTest extends \PHPUnit\Framework\TestCase
      */
     public function setUp()
     {
-        $this->binding = new ClassBinding("foo", ["bar"]);
+        $this->binding = new ClassBinding("foo", ["bar"], false);
     }
 
     /**


### PR DESCRIPTION
main goal - remove logic duplication
- doFactoryBinding ~= doInstanceBinding ~= doPrototypeBinding ~= doSingletonBinding
- getFactory ~= getInstance ~= getPrototype ~= getSingleton
- ...


done:
- merge targetedInstances, targetedInstances -> targetedInstances 
- merge universalFactories, universalPrototypes, universalSingletons, targetedFactories, targetedPrototypes, targetedSingletons  -> definitions 
- rm universalBindingTypeMappings, targetedBindingTypeMappings, mapTargetedBindingType, mapUniversalBindingType
- rm biding types, getBindingData
- inline usingTarget, stopTargeting