### PR TITLE
Routing. Improve variable matching

### DIFF
--- a/src/Opulence/Routing/Routes/Compilers/Parsers/Parser.php
+++ b/src/Opulence/Routing/Routes/Compilers/Parsers/Parser.php
@@ -17,6 +17,14 @@ use Opulence\Routing\Routes\Route;
  */
 class Parser implements IParser
 {
+    /**
+     * The maximum supported length of a PCRE subpattern name
+     * http://pcre.org/current/doc/html/pcre2pattern.html#SEC16.
+     *
+     * @internal
+     */
+    const VARIABLE_MAXIMUM_LENGTH = 32;
+
     /** @var string The variable matching regex */
     private static $variableMatchingRegex = '#:([a-zA-Z_][a-zA-Z0-9_]*)(?:=([^:\[\]/]+))?#';
     /** @var int The cursor of the currently parsed route */
@@ -104,6 +112,14 @@ class Parser implements IParser
 
         $variableName = $matches[1];
         $defaultValue = isset($matches[2]) ? $matches[2] : "";
+
+        if (strlen($variableName) > self::VARIABLE_MAXIMUM_LENGTH) {
+            throw new RouteException(sprintf(
+                'Variable name "%s" cannot be longer than %s characters. Please use a shorter name.',
+                $variableName,
+                self::VARIABLE_MAXIMUM_LENGTH)
+            );
+        }
 
         if (in_array($variableName, $this->variableNames)) {
             throw new RouteException("Route uses multiple references to \"$variableName\"");

--- a/src/Opulence/Routing/Routes/Compilers/Parsers/Parser.php
+++ b/src/Opulence/Routing/Routes/Compilers/Parsers/Parser.php
@@ -18,7 +18,7 @@ use Opulence\Routing\Routes\Route;
 class Parser implements IParser
 {
     /** @var string The variable matching regex */
-    private static $variableMatchingRegex = '#:([\w]+)(?:=([^:\[\]/]+))?#';
+    private static $variableMatchingRegex = '#:([a-zA-Z_][a-zA-Z0-9_]*)(?:=([^:\[\]/]+))?#';
     /** @var int The cursor of the currently parsed route */
     private $cursor = 0;
     /** @var array The list of variable names in the currently parsed route */
@@ -84,7 +84,7 @@ class Parser implements IParser
                 sprintf("Route has %s brackets", $bracketDepth > 0 ? "unclosed" : "unopened")
             );
         }
-      
+
         return sprintf("#^%s$#", $regex);
     }
 

--- a/tests/src/Opulence/Routing/Routes/Compilers/Parsers/ParserTest.php
+++ b/tests/src/Opulence/Routing/Routes/Compilers/Parsers/ParserTest.php
@@ -185,6 +185,13 @@ class ParserTest extends \PHPUnit\Framework\TestCase
         $this->parser->parse($route);
     }
 
+    public function testParsingWithTooLongVariableName()
+    {
+        $this->expectException(RouteException::class);
+        $route = new Route(["get"], '/:' . str_repeat('a', Parser::VARIABLE_MAXIMUM_LENGTH + 1), "foo@bar");
+        $this->parser->parse($route);
+    }
+
     /**
      * Tests parsing a path with a single variable with a default value
      */

--- a/tests/src/Opulence/Routing/Routes/Compilers/Parsers/ParserTest.php
+++ b/tests/src/Opulence/Routing/Routes/Compilers/Parsers/ParserTest.php
@@ -176,6 +176,16 @@ class ParserTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Tests parsing a path with a single variable
+     */
+    public function testParsingSingleVariableWithFirstDigit()
+    {
+        $this->expectException(RouteException::class);
+        $route = new Route(["get"], "/:0foo", "foo@bar");
+        $this->parser->parse($route);
+    }
+
+    /**
      * Tests parsing a path with a single variable with a default value
      */
     public function testParsingSingleVariableWithDefaultValue()


### PR DESCRIPTION
> Names consist of up to 32 alphanumeric characters and underscores, but must start with a non-digit.
http://www.pcre.org/original/doc/html/pcrepattern.html#SEC16

Also a PHP variable cannot start with a digit.

note: variable length check - copy paste from  [symfony routing](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Routing/RouteCompiler.php)