### PR TITLE
fix typo in IdAccessorRegistry::registerReflectionIdAccessors

### DIFF
--- a/src/Opulence/Orm/Ids/Accessors/IdAccessorRegistry.php
+++ b/src/Opulence/Orm/Ids/Accessors/IdAccessorRegistry.php
@@ -94,7 +94,7 @@ class IdAccessorRegistry implements IIdAccessorRegistry
                 $property->setAccessible(true);
                 $property->setValue($entity, $id);
             };
-            $this->registerIdAccessors($classNames, $getter, $setter);
+            $this->registerIdAccessors($className, $getter, $setter);
         }
     }
 

--- a/tests/src/Opulence/Orm/Ids/Accessors/IdAccessorRegistryTest.php
+++ b/tests/src/Opulence/Orm/Ids/Accessors/IdAccessorRegistryTest.php
@@ -12,6 +12,7 @@ use Opulence\Orm\IEntity;
 use Opulence\Orm\OrmException;
 use Opulence\Tests\Mocks\User;
 use Opulence\Tests\Orm\Ids\Accessors\Mocks\Foo;
+use Opulence\Tests\Orm\Ids\Accessors\Mocks\Bar;
 
 /**
  * Tests the Id accessor registry
@@ -91,7 +92,6 @@ class IdAccessorRegistryTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(OrmException::class);
         $this->registry->registerReflectionIdAccessors(Foo::class, "doesNotExist");
-        $foo = new Foo();
         $this->registry->getEntityId(new Foo());
     }
 
@@ -104,6 +104,20 @@ class IdAccessorRegistryTest extends \PHPUnit\Framework\TestCase
         $foo = new Foo();
         $this->registry->setEntityId($foo, 24);
         $this->assertEquals(24, $this->registry->getEntityId($foo));
+    }
+
+    /**
+     * Tests reflection accessors
+     */
+    public function testReflectionAccessorsWithTwoClasses()
+    {
+        $this->registry->registerReflectionIdAccessors([Foo::class, Bar::class], "id");
+        $foo = new Foo();
+        $bar = new Bar();
+        $this->registry->setEntityId($foo, 24);
+        $this->registry->setEntityId($bar, 42);
+        $this->assertEquals(24, $this->registry->getEntityId($foo));
+        $this->assertEquals(42, $this->registry->getEntityId($bar));
     }
 
     /**

--- a/tests/src/Opulence/Orm/Ids/Accessors/Mocks/Bar.php
+++ b/tests/src/Opulence/Orm/Ids/Accessors/Mocks/Bar.php
@@ -11,24 +11,7 @@ namespace Opulence\Tests\Orm\Ids\Accessors\Mocks;
 /**
  * Mocks a class with an Id property
  */
-class Foo
+class Bar extends Foo
 {
-    /** @var int The Id */
-    protected $id = -1;
 
-    /**
-     * @return int
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    /**
-     * @param int $id
-     */
-    public function setId($id)
-    {
-        $this->id = $id;
-    }
 }


### PR DESCRIPTION
example:
``` php 
class Foo {
    protected $id;
    public function __construct($id) { $this->id = $id; }
}

class Bar extends Foo {}

$foo = new Foo(42);
$bar = new Bar(69);

$idReg = new \Opulence\Orm\Ids\Accessors\IdAccessorRegistry();
$idReg->registerReflectionIdAccessors([\Foo::class, \Bar::class], 'id');

$idReg->getEntityId($bar);
$idReg->getEntityId($foo);
```
result:
```
69

( ! ) Fatal error: Uncaught ReflectionException: Given object is not an instance of the class this property was declared in in 
/var/www/opulence_site/vendor/opulence/opulence/src/Opulence/Orm/Ids/Accessors/IdAccessorRegistry.php:89 Stack trace: #0
/var/www/opulence_site/vendor/opulence/opulence/src/Opulence/Orm/Ids/Accessors/IdAccessorRegistry.php(89): ReflectionProperty->getValue(Object(Foo)) #1 
/var/www/opulence_site/vendor/opulence/opulence/src/Opulence/Orm/Ids/Accessors/IdAccessorRegistry.php(59): Opulence\Orm\Ids\Accessors\IdAccessorRegistry->Opulence\Orm\Ids\Accessors\{closure}(Object(Foo)) #2 
/var/www/opulence_site/public/index.php(24): Opulence\Orm\Ids\Accessors\IdAccessorRegistry->getEntityId(Object(Foo)) #3 {main} Next Opulence\Orm\OrmException: Failed to get entity Id in 
/var/www/opulence_site/vendor/opulence/opulence/src/Opulence/Orm/Ids/Accessors/IdAccessorRegistry.php on line 61
( ! ) Opulence\Orm\OrmException: Failed to get entity Id in 
/var/www/opulence_site/vendor/opulence/opulence/src/Opulence/Orm/Ids/Accessors/IdAccessorRegistry.php on line 61