### PR TITLE
Fix CSRF error on request timeout

### DIFF
--- a/src/Opulence/Framework/Http/CsrfTokenChecker.php
+++ b/src/Opulence/Framework/Http/CsrfTokenChecker.php
@@ -52,6 +52,11 @@ class CsrfTokenChecker
             $token = $request->getHeaders()->get('X-XSRF-TOKEN');
         }
 
+        // Handle missing token gracefully
+        if ($token === null) {
+            return false;
+        }
+
         return \hash_equals($session->get(self::TOKEN_INPUT_NAME), $token);
     }
 


### PR DESCRIPTION
`hash_equals` expects a string as the second parameter, therefore calling it with `null` will throw an error.