### PR TITLE
Swap parameter order to correctly set expiring value

### DIFF
--- a/src/Opulence/Cache/RedisBridge.php
+++ b/src/Opulence/Cache/RedisBridge.php
@@ -101,7 +101,7 @@ class RedisBridge implements ICacheBridge
      */
     public function set(string $key, $value, int $lifetime)
     {
-        $this->getClient()->setEx($this->getPrefixedKey($key), $value, $lifetime);
+        $this->getClient()->setEx($this->getPrefixedKey($key), $lifetime, $value);
     }
 
     /**

--- a/tests/src/Opulence/Cache/RedisBridgeTest.php
+++ b/tests/src/Opulence/Cache/RedisBridgeTest.php
@@ -156,7 +156,7 @@ class RedisBridgeTest extends \PHPUnit\Framework\TestCase
     {
         $this->client->expects($this->once())
             ->method('setEx')
-            ->with('dave:foo', 'bar', 60);
+            ->with('dave:foo', 60, 'bar');
         $this->bridge->set('foo', 'bar', 60);
     }
 


### PR DESCRIPTION
The parameters for the setEx method are set incorrectly.

According to both [phpredis](https://github.com/phpredis/phpredis#setex-psetex) and [predis](https://github.com/nrk/predis/blob/v1.1/src/ClientInterface.php#L65), the usage of setEx is `$client->setEx($key, $lifetime, $value)`.