### PR TITLE
Return an empty string if session is not set

### DIFF
--- a/src/Opulence/Sessions/Handlers/CacheSessionHandler.php
+++ b/src/Opulence/Sessions/Handlers/CacheSessionHandler.php
@@ -71,7 +71,7 @@ class CacheSessionHandler extends SessionHandler
      */
     protected function doRead(string $sessionId) : string
     {
-        return $this->cache->get($sessionId);
+        return $this->cache->get($sessionId) ?? '';
     }
 
     /**

--- a/tests/src/Opulence/Sessions/Handlers/CacheSessionHandlerTest.php
+++ b/tests/src/Opulence/Sessions/Handlers/CacheSessionHandlerTest.php
@@ -81,4 +81,12 @@ class CacheSessionHandlerTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertTrue($this->handler->open('foo', 'bar'));
     }
+
+    /**
+     * Tests reading a non-existent session
+     */
+    public function testReadingNonExistentSession()
+    {
+        $this->assertEmpty($this->handler->read('non-existent'));
+    }
 }


### PR DESCRIPTION
Using this session handler, the error `Type error: Return value of Opulence\Sessions\Handlers\CacheSessionHandler::doRead() must be of the type string, null returned` was thrown. 

This change returns an empty string if the response from the redis client is null. 