### PR TITLE
Update default path to localhost_router.php

### DIFF
--- a/src/Opulence/Framework/Console/Commands/RunAppLocallyCommand.php
+++ b/src/Opulence/Framework/Console/Commands/RunAppLocallyCommand.php
@@ -53,7 +53,7 @@ class RunAppLocallyCommand extends Command
                 null,
                 OptionTypes::REQUIRED_VALUE,
                 'The router file in your application',
-                'localhost_router.php'
+                '../localhost_router.php'
             ));
     }
 


### PR DESCRIPTION
I just installed the skeleton, but was receiving this error:

```
/project$ php apex app:runlocally
Running at http://localhost:80
[Fri Dec 22 11:05:39 2017] PHP Warning:  Unknown: failed to open stream: No such file or directory in Unknown on line 0
[Fri Dec 22 11:05:39 2017] PHP Fatal error:  Unknown: Failed opening required '/project/public/localhost_router.php' (include_path='.:/usr/share/php') in Unknown on line 0
```

This patch I am submitting fixed the issue for me.  