### PR TITLE
Fix Migration.template creation date string constant

### DIFF
--- a/src/Opulence/Framework/Databases/Console/Commands/templates/Migration.template
+++ b/src/Opulence/Framework/Databases/Console/Commands/templates/Migration.template
@@ -13,7 +13,7 @@ class {{class}} extends Migration
      */
     public static function getCreationDate() : DateTime
     {
-        return DateTime::createFromFormat(DateTime::ATOM, "{{creationDate}}");
+        return DateTime::createFromFormat(DateTime::ATOM, '{{creationDate}}');
     }
     
     /**


### PR DESCRIPTION
There is no point in using interpolation for that string constant.