### PR TITLE
Fix IRepository::getById phpDoc

### DIFF
--- a/src/Opulence/Orm/Repositories/IRepository.php
+++ b/src/Opulence/Orm/Repositories/IRepository.php
@@ -44,7 +44,7 @@ interface IRepository
     /**
      * Gets the entity with the input Id
      *
-     * @param int|string $id The Id of the entity we're searching for
+     * @param int|string|object $id The Id of the entity we're searching for
      * @return object The entity with the input Id
      * @throws OrmException Thrown if there was no entity with the input Id
      */


### PR DESCRIPTION
In situations when DDD (domain driven design) methodology applied for develop persistence layer typical use of `getById` method is:

```php
$entity = $repository->getById(new EntityId(...));
```

where `EntityId` is value object which represents entity identifier. This PR fix this method phpDoc.