### PR TITLE
Fix migrations loading inverse order

### DIFF
--- a/src/Opulence/Databases/Migrations/FileMigrationFinder.php
+++ b/src/Opulence/Databases/Migrations/FileMigrationFinder.php
@@ -67,7 +67,7 @@ class FileMigrationFinder
 
         // Sort the migration classes by their creation dates
         usort($migrationClassNames, function (string $a, string $b) {
-            return $b::getCreationDate() <=> $a::getCreationDate();
+            return $a::getCreationDate() <=> $b::getCreationDate();
         });
 
         return $migrationClassNames;

--- a/src/Opulence/Databases/Tests/Migrations/FileMigrationFinderTest.php
+++ b/src/Opulence/Databases/Tests/Migrations/FileMigrationFinderTest.php
@@ -59,9 +59,9 @@ class FileMigrationFinderTest extends \PHPUnit\Framework\TestCase
     public function testMigrationsAreFoundInSubdirectories() : void
     {
         $expectedMigrations = [
-            MigrationB::class,
+            MigrationC::class,
             MigrationA::class,
-            MigrationC::class
+            MigrationB::class,
         ];
         $this->assertEquals(
             $expectedMigrations,


### PR DESCRIPTION
If you remove all your database, and run migrations, the latest migration is run first which fails. The cause is that the migrations are ordered in the wrong order.