### PR TITLE
Fix UrlGenerator::createFromName PHPDocs

### DIFF
--- a/src/Opulence/Routing/Urls/UrlGenerator.php
+++ b/src/Opulence/Routing/Urls/UrlGenerator.php
@@ -38,7 +38,7 @@ class UrlGenerator
      * This function accepts variable-length arguments after the name
      *
      * @param string $name The named of the route whose URL we're generating
-     * @param array $args,... The list of arguments to pass in
+     * @param string  ...$args The list of arguments to pass in
      * @return string The generated URL if the route exists, otherwise an empty string
      * @throws URLException Thrown if there was an error generating the URL
      */


### PR DESCRIPTION
Related problems found by [phan](https://github.com/phan/phan):

```
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:185 PhanTypeMismatchArgument Argument 2 ($args) is 'foo' but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:185 PhanTypeMismatchArgument Argument 3 ($args) is 'bar' but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:185 PhanTypeMismatchArgument Argument 4 ($args) is 23 but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:185 PhanTypeMismatchArgument Argument 5 ($args) is 'edit' but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:210 PhanTypeMismatchArgument Argument 2 ($args) is 23 but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:213 PhanTypeMismatchArgument Argument 2 ($args) is 'foo' but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:249 PhanTypeMismatchArgument Argument 2 ($args) is 'bar' but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:253 PhanTypeMismatchArgument Argument 2 ($args) is 'bar' but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:253 PhanTypeMismatchArgument Argument 3 ($args) is 'baz' but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:283 PhanTypeMismatchArgument Argument 2 ($args) is 'bar' but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:304 PhanTypeMismatchArgument Argument 2 ($args) is 23 but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:304 PhanTypeMismatchArgument Argument 3 ($args) is 'edit' but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:307 PhanTypeMismatchArgument Argument 2 ($args) is 'foo' but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:307 PhanTypeMismatchArgument Argument 3 ($args) is 'bar' but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:317 PhanTypeMismatchArgument Argument 2 ($args) is 'notANumber' but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php:343 PhanTypeMismatchArgument Argument 2 ($args) is 23 but \Opulence\Routing\Urls\UrlGenerator::createFromName() takes array defined at src/Opulence/Routing/Urls/UrlGenerator.php:45
src/Opulence/Routing/Urls/UrlGenerator.php:41 PhanMismatchVariadicParam array $args is not variadic in comment, but variadic in param (...$args)
```