### PR TITLE
Upgrade PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "ext-pdo": "*",
     "phpredis/phpredis": "3.0.*",
     "predis/predis": "1.1.*@dev",
-    "phpunit/phpunit": "~6.2"
+    "phpunit/phpunit": "~7.5"
   },
   "repositories": [
     {

--- a/src/Opulence/Databases/Tests/Providers/Types/TypeMapperTest.php
+++ b/src/Opulence/Databases/Tests/Providers/Types/TypeMapperTest.php
@@ -91,14 +91,14 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
             $this->typeMapperWithNoProvider->fromSqlDate($sqlDate, $this->provider)->format('Ymd')
         );
         // Make sure the hour, minutes, and seconds are zeroed out
-        $this->assertEquals('000',
+        $this->assertEquals('000000',
             $this->typeMapperWithNoProvider->fromSqlDate($sqlDate, $this->provider)->format('His'));
         $this->assertEquals(
             $phpDate->format('Ymd'),
             $this->typeMapperWithProvider->fromSqlDate($sqlDate)->format('Ymd')
         );
         // Make sure the hour, minutes, and seconds are zeroed out
-        $this->assertEquals('000', $this->typeMapperWithProvider->fromSqlDate($sqlDate)->format('His'));
+        $this->assertEquals('000000', $this->typeMapperWithProvider->fromSqlDate($sqlDate)->format('His'));
     }
 
     /**


### PR DESCRIPTION
PHPUnit 8.x requires PHP 7.2, therefore we're stuck on a somewhat older version.