### PR TITLE
Add Expression functionality

### DIFF
--- a/src/Opulence/QueryBuilders/Expression.php
+++ b/src/Opulence/QueryBuilders/Expression.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * Opulence
+ *
+ * @link      https://www.opulencephp.com
+ * @copyright Copyright (C) 2017 David Young
+ * @license   https://github.com/opulencephp/Opulence/blob/master/LICENSE.md
+ */
+
+namespace Opulence\QueryBuilders;
+
+/**
+ * Expression is designed to be used for setting values in INSERT and UPDATE statements
+ * It is not intended to be used in WHERE clauses or as columns in SELECT queries
+ */
+class Expression
+{
+    /** @var string The expression to use */
+    protected $expression = '';
+
+    /** @var array[] */
+    protected $values = [];
+
+    /**
+     * Expression constructor.
+     *
+     * @param string $expression
+     * @param mixed  ...$values
+     *
+     * @throws InvalidQueryException
+     */
+    public function __construct(string $expression, ...$values)
+    {
+        $this->expression = $expression;
+
+        foreach ($values as $value) {
+            if (is_scalar($value)) {
+                $value = [$value, \PDO::PARAM_STR];
+            }
+
+            if (!is_array($value) || count($value) !== 2) {
+                throw new InvalidQueryException('Incorrect number of items in expression value array');
+            }
+
+            if (!array_key_exists(0, $value) || !array_key_exists(1, $value)) {
+                throw new InvalidQueryException('Incorrect keys in expression value array');
+            }
+
+            if (!is_scalar($value[0]) || !is_numeric($value[1]) || $value[1] < 0) {
+                throw new InvalidQueryException('Incorrect expression values');
+            }
+
+            $this->values[] = $value;
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters() : array
+    {
+        return $this->values;
+    }
+
+    public function getSql() : string
+    {
+        return $this->expression;
+    }
+}

--- a/src/Opulence/QueryBuilders/InsertQuery.php
+++ b/src/Opulence/QueryBuilders/InsertQuery.php
@@ -64,11 +64,19 @@ class InsertQuery extends Query
      */
     public function getSql() : string
     {
-        $sql = "INSERT INTO {$this->tableName}"
-            . ' (' . implode(', ', array_keys($this->augmentingQueryBuilder->getColumnNamesToValues())) . ') VALUES ('
-            . implode(', ',
-                array_fill(0, count(array_values($this->augmentingQueryBuilder->getColumnNamesToValues())), '?'))
-            . ')';
+        $namesToValues = $this->augmentingQueryBuilder->getColumnNamesToValues();
+
+        $sql = 'INSERT INTO ' . $this->tableName . ' (' . implode(', ', array_keys($namesToValues)) . ') VALUES (';
+
+        $values = [];
+        foreach ($namesToValues as $value) {
+            if ($value instanceof Expression) {
+                $values[] = $value->getSql();
+            } else {
+                $values[] = '?';
+            }
+        }
+        $sql .= implode(', ', $values) . ')';
 
         return $sql;
     }

--- a/src/Opulence/QueryBuilders/Query.php
+++ b/src/Opulence/QueryBuilders/Query.php
@@ -124,6 +124,11 @@ abstract class Query
     public function addUnnamedPlaceholderValues(array $placeholderValues) : self
     {
         foreach ($placeholderValues as $value) {
+            if ($value instanceof Expression) {
+                $this->addUnnamedPlaceholderValues($value->getParameters());
+                continue;
+            }
+
             if (is_array($value)) {
                 if (count($value) !== 2) {
                     throw new InvalidQueryException('Incorrect number of items in value array');

--- a/src/Opulence/QueryBuilders/Tests/InsertQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/InsertQueryTest.php
@@ -10,6 +10,7 @@
 
 namespace Opulence\QueryBuilders\Tests;
 
+use Opulence\QueryBuilders\Expression;
 use Opulence\QueryBuilders\InsertQuery;
 
 /**
@@ -27,7 +28,7 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('INSERT INTO users (name, email) VALUES (?, ?)', $query->getSql());
         $this->assertEquals([
             ['dave', \PDO::PARAM_STR],
-            ['foo@bar.com', \PDO::PARAM_STR]
+            ['foo@bar.com', \PDO::PARAM_STR],
         ], $query->getParameters());
     }
 
@@ -45,16 +46,55 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Tests a query with a simple UpsertExpression
+     */
+    public function testSimpleExpression()
+    {
+        $query = new InsertQuery('users',
+            ['name' => 'dave', 'email' => 'foo@bar.com', 'valid_until' => new Expression('NOW()')]);
+        $this->assertEquals('INSERT INTO users (name, email, valid_until) VALUES (?, ?, NOW())', $query->getSql());
+        $this->assertEquals([
+            ['dave', \PDO::PARAM_STR],
+            ['foo@bar.com', \PDO::PARAM_STR],
+        ], $query->getParameters());
+    }
+
+    /**
+     * Tests a query with a complex UpsertExpression
+     */
+    public function testComplexExpression()
+    {
+        $query = new InsertQuery('users',
+            [
+                'name' => 'dave',
+                'email' => 'foo@bar.com',
+                'is_val_even' => new Expression('(val + ?) % ?', ['1', \PDO::PARAM_INT], [2, \PDO::PARAM_INT])
+            ]);
+        $this->assertEquals('INSERT INTO users (name, email, is_val_even) VALUES (?, ?, (val + ?) % ?)',
+            $query->getSql());
+        $this->assertSame([
+            ['dave', \PDO::PARAM_STR],
+            ['foo@bar.com', \PDO::PARAM_STR],
+            ['1', \PDO::PARAM_INT],
+            [2, \PDO::PARAM_INT],
+        ], $query->getParameters());
+    }
+
+    /**
      * Tests all the methods in a single, complicated query
      */
     public function testEverything()
     {
+        $expr = new Expression("(val + ?) % ?", ['1', \PDO::PARAM_INT]);
         $query = new InsertQuery('users', ['name' => 'dave']);
-        $query->addColumnValues(['email' => 'foo@bar.com']);
-        $this->assertEquals('INSERT INTO users (name, email) VALUES (?, ?)', $query->getSql());
-        $this->assertEquals([
+        $query->addColumnValues(['email' => 'foo@bar.com', 'is_val_even' => $expr])
+            ->addUnnamedPlaceholderValues([[2, \PDO::PARAM_INT]]);
+        $this->assertEquals('INSERT INTO users (name, email, is_val_even) VALUES (?, ?, (val + ?) % ?)', $query->getSql());
+        $this->assertSame([
             ['dave', \PDO::PARAM_STR],
-            ['foo@bar.com', \PDO::PARAM_STR]
+            ['foo@bar.com', \PDO::PARAM_STR],
+            ['1', \PDO::PARAM_INT],
+            [2, \PDO::PARAM_INT],
         ], $query->getParameters());
     }
 }

--- a/src/Opulence/QueryBuilders/Tests/MySql/InsertQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/MySql/InsertQueryTest.php
@@ -10,6 +10,7 @@
 
 namespace Opulence\QueryBuilders\Tests\MySql;
 
+use Opulence\QueryBuilders\Expression;
 use Opulence\QueryBuilders\MySql\InsertQuery;
 use PDO;
 
@@ -52,14 +53,21 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
      */
     public function testEverything()
     {
-        $query = new InsertQuery('users', ['name' => 'dave', 'email' => 'foo@bar.com']);
+        $query = new InsertQuery('users',
+            [
+                'name' => 'dave',
+                'email' => 'foo@bar.com',
+                'is_val_even' => new Expression('(val + ?) % ?', ['1', \PDO::PARAM_INT], [2, \PDO::PARAM_INT])
+            ]);
         $query->update(['name' => 'dave'])
             ->addUpdateColumnValues(['email' => 'foo@bar.com']);
-        $this->assertEquals('INSERT INTO users (name, email) VALUES (?, ?) ON DUPLICATE KEY UPDATE name = ?, email = ?',
+        $this->assertEquals('INSERT INTO users (name, email, is_val_even) VALUES (?, ?, (val + ?) % ?) ON DUPLICATE KEY UPDATE name = ?, email = ?',
             $query->getSql());
-        $this->assertEquals([
+        $this->assertSame([
             ['dave', PDO::PARAM_STR],
-            ['foo@bar.com', PDO::PARAM_STR]
+            ['foo@bar.com', PDO::PARAM_STR],
+            ['1', \PDO::PARAM_INT],
+            [2, \PDO::PARAM_INT],
         ], $query->getParameters());
     }
 

--- a/src/Opulence/QueryBuilders/Tests/PostgreSql/UpdateQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/PostgreSql/UpdateQueryTest.php
@@ -10,6 +10,7 @@
 
 namespace Opulence\QueryBuilders\Tests\PostgreSql;
 
+use Opulence\QueryBuilders\Expression;
 use Opulence\QueryBuilders\PostgreSql\UpdateQuery;
 use PDO;
 
@@ -37,19 +38,22 @@ class UpdateQueryTest extends \PHPUnit\Framework\TestCase
      */
     public function testEverything()
     {
+        $expr = new Expression("(val + ?) % ?", ['1', PDO::PARAM_INT]);
         $query = new UpdateQuery('users', 'u', ['name' => 'david']);
-        $query->addColumnValues(['email' => 'bar@foo.com'])
+        $query->addColumnValues(['email' => 'bar@foo.com', 'is_val_even' => $expr])
             ->where('u.id = ?', 'emails.userid = u.id', 'emails.email = ?')
             ->orWhere('u.name = ?')
             ->andWhere('subscriptions.userid = u.id', "subscriptions.type = 'customer'")
             ->returning('u.id')
             ->addReturning('u.name')
-            ->addUnnamedPlaceholderValues([[18175, PDO::PARAM_INT], 'foo@bar.com', 'dave']);
-        $this->assertEquals("UPDATE users AS u SET name = ?, email = ? WHERE (u.id = ?) AND (emails.userid = u.id) AND (emails.email = ?) OR (u.name = ?) AND (subscriptions.userid = u.id) AND (subscriptions.type = 'customer') RETURNING u.id, u.name",
+            ->addUnnamedPlaceholderValues([[2, PDO::PARAM_INT], [18175, PDO::PARAM_INT], 'foo@bar.com', 'dave']);
+        $this->assertEquals("UPDATE users AS u SET name = ?, email = ?, is_val_even = (val + ?) % ? WHERE (u.id = ?) AND (emails.userid = u.id) AND (emails.email = ?) OR (u.name = ?) AND (subscriptions.userid = u.id) AND (subscriptions.type = 'customer') RETURNING u.id, u.name",
             $query->getSql());
         $this->assertEquals([
             ['david', PDO::PARAM_STR],
             ['bar@foo.com', PDO::PARAM_STR],
+            ['1', PDO::PARAM_INT],
+            [2, PDO::PARAM_INT],
             [18175, PDO::PARAM_INT],
             ['foo@bar.com', PDO::PARAM_STR],
             ['dave', PDO::PARAM_STR]

--- a/src/Opulence/QueryBuilders/Tests/SelectQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/SelectQueryTest.php
@@ -161,7 +161,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
      */
     public function testEverything()
     {
-        $query = new SelectQuery('u.id', 'u.name', 'e.email');
+        $query = new SelectQuery('u.id', 'u.name', 'e.email', 'CHARACTER_LENGTH(e.email) AS email_length');
         $query->addSelectExpression('p.password')
             ->from('users', 'u')
             ->innerJoin('log', 'l', 'l.userid = u.id')
@@ -181,7 +181,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
             ->addOrderBy('u.name ASC')
             ->limit(2)
             ->offset(1);
-        $this->assertEquals('SELECT u.id, u.name, e.email, p.password FROM users AS u INNER JOIN log AS l ON l.userid = u.id LEFT JOIN emails AS e ON e.userid = u.id RIGHT JOIN password AS p ON p.userid = u.id WHERE (u.id <> 10) AND (u.name <> :notAllowedName) AND (u.id <> 9) OR (u.name = :allowedName) GROUP BY u.id, u.name, e.email, p.password HAVING (count(*) > :minCount) AND (count(*) < 5) OR (count(*) = 2) ORDER BY u.id DESC, u.name ASC LIMIT 2 OFFSET 1',
+        $this->assertEquals('SELECT u.id, u.name, e.email, CHARACTER_LENGTH(e.email) AS email_length, p.password FROM users AS u INNER JOIN log AS l ON l.userid = u.id LEFT JOIN emails AS e ON e.userid = u.id RIGHT JOIN password AS p ON p.userid = u.id WHERE (u.id <> 10) AND (u.name <> :notAllowedName) AND (u.id <> 9) OR (u.name = :allowedName) GROUP BY u.id, u.name, e.email, p.password HAVING (count(*) > :minCount) AND (count(*) < 5) OR (count(*) = 2) ORDER BY u.id DESC, u.name ASC LIMIT 2 OFFSET 1',
             $query->getSql());
         $this->assertEquals([
             'notAllowedName' => ['dave', PDO::PARAM_STR],

--- a/src/Opulence/QueryBuilders/UpdateQuery.php
+++ b/src/Opulence/QueryBuilders/UpdateQuery.php
@@ -91,10 +91,14 @@ class UpdateQuery extends Query
         $sql = 'UPDATE ' . $this->tableName . (empty($this->tableAlias) ? '' : ' AS ' . $this->tableAlias) . ' SET';
 
         foreach ($this->augmentingQueryBuilder->getColumnNamesToValues() as $columnName => $value) {
-            $sql .= ' ' . $columnName . ' = ?,';
+            if ($value instanceof Expression) {
+                $sql .= ' ' . $columnName . ' = ' . $value->getSql() . ',';
+            } else {
+                $sql .= ' ' . $columnName . ' = ?,';
+            }
         }
 
-        $sql = trim($sql, ',');
+        $sql = rtrim($sql, ',');
         // Add any conditions
         $sql .= $this->conditionalQueryBuilder
             ->getClauseConditionSql('WHERE', $this->conditionalQueryBuilder->getWhereConditions());


### PR DESCRIPTION
Feature to enable setting values via SQL expressions and not just simple values.

### values in expressions

Strictly speaking `Expression` doesn't have to handle values, but it's probably nicer to set up queries with it.

With `Expressions` handling values:
```php
$expr = new Expression('(val + ?) % ?', ['1', PDO::PARAM_INT], [2, PDO::PARAM_INT]);
$query = new UpdateQuery('users', 'u', ['name' => 'david']);
$query->addColumnValues(['email' => 'bar@foo.com', 'is_val_even' => $expr])
    ->where('u.id = ?', 'emails.userid = u.id', 'emails.email = ?')
    ->orWhere('u.name = ?')
    ->andWhere('subscriptions.userid = u.id', "subscriptions.type = 'customer'")
    ->addUnnamedPlaceholderValues([[18175, PDO::PARAM_INT], 'foo@bar.com', 'dave']);
```

Without this features it becomes:
```php
$expr = new Expression('(val + ?) % ?');
$query = new UpdateQuery('users', 'u', ['name' => 'david']);
$query->addColumnValues(['email' => 'bar@foo.com', 'is_val_even' => $expr])
    ->where('u.id = ?', 'emails.userid = u.id', 'emails.email = ?')
    ->orWhere('u.name = ?')
    ->andWhere('subscriptions.userid = u.id', "subscriptions.type = 'customer'")
    ->addUnnamedPlaceholderValues([[1, \PDO::PARAM_INT], [2, PDO::PARAM_INT], [18175, PDO::PARAM_INT], 'foo@bar.com', 'dave']);
```

If you feel this feature is not needed, just let me know and I'll remove it.