### PR TITLE
Add option to validate non-required fields with empty value

### DIFF
--- a/src/Opulence/Validation/Rules/Rules.php
+++ b/src/Opulence/Validation/Rules/Rules.php
@@ -34,6 +34,8 @@ class Rules
     protected $rules = [];
     /** @var bool Whether or not a value is required */
     protected $isRequired = false;
+    /** @var bool Whether or not validating a value should be forced, even if it is empty and not required */
+    protected $validateEmptyFields = false;
     /** @var bool Whether or not we're building a conditional rule */
     protected $inCondition = false;
 
@@ -327,8 +329,8 @@ class Rules
         $passes = true;
 
         foreach ($this->rules as $rule) {
-            // Non-required fields do not need to evaluate all rules when empty
-            if (!$this->isRequired) {
+            // Non-required fields do not need to evaluate all rules when empty, unless it's explicitly required
+            if (!$this->isRequired && !$this->validateEmptyFields) {
                 if (
                     $value === null ||
                     (is_string($value) && $value === '') ||
@@ -389,7 +391,7 @@ class Rules
      */
     public function validateEmpty() : self
     {
-        $this->isRequired = true;
+        $this->validateEmptyFields = true;
 
         return $this;
     }

--- a/src/Opulence/Validation/Rules/Rules.php
+++ b/src/Opulence/Validation/Rules/Rules.php
@@ -383,6 +383,18 @@ class Rules
     }
 
     /**
+     * Marks a field as to be validated even if empty
+     *
+     * @return self For method chaining
+     */
+    public function validateEmpty() : self
+    {
+        $this->isRequired = true;
+
+        return $this;
+    }
+
+    /**
      * Adds an error
      *
      * @param IRule $rule The rule that failed

--- a/src/Opulence/Validation/Tests/Rules/RulesTest.php
+++ b/src/Opulence/Validation/Tests/Rules/RulesTest.php
@@ -426,6 +426,24 @@ class RulesTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Tests the numeric rule is ignored in case the value is empty
+     */
+    public function testNumericRuleIsSkippedIfValueIsEmpty()
+    {
+        $this->assertSame($this->rules, $this->rules->numeric());
+        $this->assertTrue($this->rules->pass(''));
+    }
+
+    /**
+     * Tests the numeric rule is enforced in case the value is empty if the validateEmpty is called on rules
+     */
+    public function testValidateEmptyAllowsValidatingFieldsWithEmptyValue()
+    {
+        $this->assertSame($this->rules, $this->rules->validateEmpty()->numeric());
+        $this->assertFalse($this->rules->pass(''));
+    }
+
+    /**
      * Tests that rule extensions in a condition are respected
      */
     public function testRuleExtensionsInConditionAreRespected()


### PR DESCRIPTION
This PR will/would allow one to create validation rules like `AtLeastOne` or `ExactlyOne` to validate a group of fields without much hassle