### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/src/Opulence/Applications/Tests/ApplicationTest.php
+++ b/src/Opulence/Applications/Tests/ApplicationTest.php
@@ -29,7 +29,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->dispatcher = $this->createMock(ITaskDispatcher::class);
         $this->application = new Application($this->dispatcher);

--- a/src/Opulence/Applications/Tests/Tasks/Dispatchers/TaskDispatcherTest.php
+++ b/src/Opulence/Applications/Tests/Tasks/Dispatchers/TaskDispatcherTest.php
@@ -24,7 +24,7 @@ class TaskDispatcherTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->dispatcher = new TaskDispatcher();
     }

--- a/src/Opulence/Authentication/Tests/AuthenticationContextTest.php
+++ b/src/Opulence/Authentication/Tests/AuthenticationContextTest.php
@@ -25,7 +25,7 @@ class AuthenticationContextTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->context = new AuthenticationContext();
     }

--- a/src/Opulence/Authentication/Tests/Clients/ClientTest.php
+++ b/src/Opulence/Authentication/Tests/Clients/ClientTest.php
@@ -23,7 +23,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->client = new Client(123, 'foo', 'bar');
     }

--- a/src/Opulence/Authentication/Tests/Credentials/Authenticators/AuthenticatorRegistryTest.php
+++ b/src/Opulence/Authentication/Tests/Credentials/Authenticators/AuthenticatorRegistryTest.php
@@ -25,7 +25,7 @@ class AuthenticatorRegistryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->registry = new AuthenticatorRegistry();
     }

--- a/src/Opulence/Authentication/Tests/Credentials/Authenticators/AuthenticatorTest.php
+++ b/src/Opulence/Authentication/Tests/Credentials/Authenticators/AuthenticatorTest.php
@@ -29,7 +29,7 @@ class AuthenticatorTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->authenticatorRegistry = $this->createMock(IAuthenticatorRegistry::class);
         $this->authenticator = new Authenticator($this->authenticatorRegistry);

--- a/src/Opulence/Authentication/Tests/Credentials/Authenticators/JwtAuthenticatorTest.php
+++ b/src/Opulence/Authentication/Tests/Credentials/Authenticators/JwtAuthenticatorTest.php
@@ -39,7 +39,7 @@ class JwtAuthenticatorTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         /** @var ISigner $signer */
         $signer = $this->createMock(ISigner::class);

--- a/src/Opulence/Authentication/Tests/Credentials/Authenticators/RefreshTokenAuthenticatorTest.php
+++ b/src/Opulence/Authentication/Tests/Credentials/Authenticators/RefreshTokenAuthenticatorTest.php
@@ -42,7 +42,7 @@ class RefreshTokenAuthenticatorTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->refreshTokenRepository = $this->createMock(IJwtRepository::class);
         /** @var ISigner $signer */

--- a/src/Opulence/Authentication/Tests/Credentials/Authenticators/UsernamePasswordAuthenticatorTest.php
+++ b/src/Opulence/Authentication/Tests/Credentials/Authenticators/UsernamePasswordAuthenticatorTest.php
@@ -35,7 +35,7 @@ class UsernamePasswordAuthenticatorTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->userRepository = $this->createMock(IUserRepository::class);
         $this->roleRepository = $this->createMock(IRoleRepository::class);

--- a/src/Opulence/Authentication/Tests/Credentials/CredentialTest.php
+++ b/src/Opulence/Authentication/Tests/Credentials/CredentialTest.php
@@ -23,7 +23,7 @@ class CredentialTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->credential = new Credential('foo', ['bar' => 'baz']);
     }

--- a/src/Opulence/Authentication/Tests/Credentials/Factories/AccessTokenCredentialFactoryTest.php
+++ b/src/Opulence/Authentication/Tests/Credentials/Factories/AccessTokenCredentialFactoryTest.php
@@ -40,7 +40,7 @@ class AccessTokenCredentialFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->signer = $this->createMock(ISigner::class);
         $this->signer->expects($this->any())

--- a/src/Opulence/Authentication/Tests/Credentials/Factories/RefreshTokenCredentialFactoryTest.php
+++ b/src/Opulence/Authentication/Tests/Credentials/Factories/RefreshTokenCredentialFactoryTest.php
@@ -33,7 +33,7 @@ class RefreshTokenCredentialFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->signer = $this->createMock(ISigner::class);
         $this->signer->expects($this->any())

--- a/src/Opulence/Authentication/Tests/PrincipalTest.php
+++ b/src/Opulence/Authentication/Tests/PrincipalTest.php
@@ -23,7 +23,7 @@ class PrincipalTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->principal = new Principal('foo', 'bar', ['baz']);
     }

--- a/src/Opulence/Authentication/Tests/SubjectTest.php
+++ b/src/Opulence/Authentication/Tests/SubjectTest.php
@@ -26,7 +26,7 @@ class SubjectTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->subject = new Subject();
     }

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/JwtHeaderTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/JwtHeaderTest.php
@@ -25,7 +25,7 @@ class JwtHeaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->header = new JwtHeader(Algorithms::SHA512);
     }

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/JwtPayloadTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/JwtPayloadTest.php
@@ -25,7 +25,7 @@ class JwtPayloadTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->payload = new JwtPayload();
     }

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/SignedJwtTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/SignedJwtTest.php
@@ -32,7 +32,7 @@ class SignedJwtTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->header = new JwtHeader();
         $this->payload = new JwtPayload();

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/UnsignedJwtTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/UnsignedJwtTest.php
@@ -29,7 +29,7 @@ class UnsignedJwtTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->header = new JwtHeader();
         $this->payload = new JwtPayload();

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/AudienceVerifierTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/AudienceVerifierTest.php
@@ -28,7 +28,7 @@ class AudienceVerifierTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->jwt = $this->getMockBuilder(SignedJwt::class)
             ->disableOriginalConstructor()

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/ExpirationVerifierTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/ExpirationVerifierTest.php
@@ -31,7 +31,7 @@ class ExpirationVerifierTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->verifier = new ExpirationVerifier();
         $this->jwt = $this->getMockBuilder(SignedJwt::class)

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/IssuerVerifierTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/IssuerVerifierTest.php
@@ -30,7 +30,7 @@ class IssuerVerifierTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->verifier = new IssuerVerifier('foo');
         $this->jwt = $this->getMockBuilder(SignedJwt::class)

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/JwtVerifierTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/JwtVerifierTest.php
@@ -33,7 +33,7 @@ class JwtVerifierTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->verifier = new JwtVerifier();
         $this->signer = $this->createMock(ISigner::class);

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/NotBeforeVerifierTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/NotBeforeVerifierTest.php
@@ -31,7 +31,7 @@ class NotBeforeVerifierTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->verifier = new NotBeforeVerifier();
         $this->jwt = $this->getMockBuilder(SignedJwt::class)

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/SignatureVerifierTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/SignatureVerifierTest.php
@@ -32,7 +32,7 @@ class SignatureVerifierTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->signer = $this->createMock(ISigner::class);
         $this->verifier = new SignatureVerifier($this->signer);

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/SubjectVerifierTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/SubjectVerifierTest.php
@@ -30,7 +30,7 @@ class SubjectVerifierTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->verifier = new SubjectVerifier('foo');
         $this->jwt = $this->getMockBuilder(SignedJwt::class)

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/VerificationContextTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/VerificationContextTest.php
@@ -26,7 +26,7 @@ class VerificationContextTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->signer = $this->createMock(ISigner::class);
         $this->context = new VerificationContext($this->signer);

--- a/src/Opulence/Authentication/Tests/Tokens/Signatures/Factories/SignerFactoryTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/Signatures/Factories/SignerFactoryTest.php
@@ -27,7 +27,7 @@ class SignerFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->factory = new SignerFactory();
     }

--- a/src/Opulence/Authentication/Tests/Tokens/Signatures/HmacSignerTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/Signatures/HmacSignerTest.php
@@ -28,7 +28,7 @@ class HmacSignerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->unsignedToken = $this->createMock(IUnsignedToken::class);
         $this->unsignedToken->expects($this->any())

--- a/src/Opulence/Authentication/Tests/Tokens/Signatures/RsaSsaPkcsSignerTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/Signatures/RsaSsaPkcsSignerTest.php
@@ -28,7 +28,7 @@ class RsaSsaPkcsSignerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->unsignedToken = $this->createMock(IUnsignedToken::class);
         $this->unsignedToken->expects($this->any())

--- a/src/Opulence/Authorization/Tests/AuthorityTest.php
+++ b/src/Opulence/Authorization/Tests/AuthorityTest.php
@@ -28,7 +28,7 @@ class AuthorityTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->permissionRegistry = new PermissionRegistry();
         $this->roles = $this->createMock(IRoles::class);

--- a/src/Opulence/Authorization/Tests/Permissions/PermissionRegistryTest.php
+++ b/src/Opulence/Authorization/Tests/Permissions/PermissionRegistryTest.php
@@ -23,7 +23,7 @@ class PermissionRegistryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->registry = new PermissionRegistry();
     }

--- a/src/Opulence/Authorization/Tests/Roles/RoleMembershipTest.php
+++ b/src/Opulence/Authorization/Tests/Roles/RoleMembershipTest.php
@@ -26,7 +26,7 @@ class RoleMembershipTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->role = new Role(1, 'foo');
         $this->membership = new RoleMembership(1, 2, $this->role);

--- a/src/Opulence/Authorization/Tests/Roles/RoleTest.php
+++ b/src/Opulence/Authorization/Tests/Roles/RoleTest.php
@@ -23,7 +23,7 @@ class RoleTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->role = new Role(1, 'foo');
     }

--- a/src/Opulence/Authorization/Tests/Roles/RolesTest.php
+++ b/src/Opulence/Authorization/Tests/Roles/RolesTest.php
@@ -32,7 +32,7 @@ class RolesTest extends \PHPUnit\Framework\TestCase
     /**
      * Tests up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->roleRepository = $this->createMock(IRoleRepository::class);
         $this->roleMembershipRepository = $this->createMock(IRoleMembershipRepository::class);

--- a/src/Opulence/Cache/Tests/ArrayBridgeTest.php
+++ b/src/Opulence/Cache/Tests/ArrayBridgeTest.php
@@ -23,7 +23,7 @@ class ArrayBridgeTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->bridge = new ArrayBridge();
     }

--- a/src/Opulence/Cache/Tests/FileBridgeTest.php
+++ b/src/Opulence/Cache/Tests/FileBridgeTest.php
@@ -47,7 +47,7 @@ class FileBridgeTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->bridge = new FileBridge(__DIR__ . '/tmp');
     }

--- a/src/Opulence/Cache/Tests/MemcachedBridgeTest.php
+++ b/src/Opulence/Cache/Tests/MemcachedBridgeTest.php
@@ -29,7 +29,7 @@ class MemcachedBridgeTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $methods = ['decrement', 'delete', 'flush', 'get', 'getResultCode', 'increment', 'set'];
         $this->client = $this->getMockBuilder(Client::class)

--- a/src/Opulence/Cache/Tests/RedisBridgeTest.php
+++ b/src/Opulence/Cache/Tests/RedisBridgeTest.php
@@ -29,7 +29,7 @@ class RedisBridgeTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $methods = ['get', 'decrBy', 'del', 'flushAll', 'incrBy', 'setEx'];
         $this->client = $this->getMockBuilder(Client::class)

--- a/src/Opulence/Collections/Tests/ArrayListTest.php
+++ b/src/Opulence/Collections/Tests/ArrayListTest.php
@@ -24,7 +24,7 @@ class ArrayListTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->arrayList = new ArrayList();
     }

--- a/src/Opulence/Collections/Tests/HashSetTest.php
+++ b/src/Opulence/Collections/Tests/HashSetTest.php
@@ -24,7 +24,7 @@ class HashSetTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->set = new HashSet();
     }

--- a/src/Opulence/Collections/Tests/HashTableTest.php
+++ b/src/Opulence/Collections/Tests/HashTableTest.php
@@ -27,7 +27,7 @@ class HashTableTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->hashTable = new HashTable();
     }

--- a/src/Opulence/Collections/Tests/KeyHasherTest.php
+++ b/src/Opulence/Collections/Tests/KeyHasherTest.php
@@ -25,7 +25,7 @@ class KeyHasherTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->keyHasher = new KeyHasher();
     }

--- a/src/Opulence/Collections/Tests/QueueTest.php
+++ b/src/Opulence/Collections/Tests/QueueTest.php
@@ -23,7 +23,7 @@ class QueueTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->queue = new Queue();
     }

--- a/src/Opulence/Collections/Tests/StackTest.php
+++ b/src/Opulence/Collections/Tests/StackTest.php
@@ -23,7 +23,7 @@ class StackTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->stack = new Stack();
     }

--- a/src/Opulence/Console/Tests/Commands/CommandTest.php
+++ b/src/Opulence/Console/Tests/Commands/CommandTest.php
@@ -40,7 +40,7 @@ class CommandTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->commandCollection = new CommandCollection(new CommandCompiler());
         $this->commandCollection->add(new HappyHolidayCommand($this->commandCollection));

--- a/src/Opulence/Console/Tests/Commands/CommandsCollectionTest.php
+++ b/src/Opulence/Console/Tests/Commands/CommandsCollectionTest.php
@@ -32,7 +32,7 @@ class CommandsCollectionTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->collection = new CommandCollection(new CommandCompiler());
     }

--- a/src/Opulence/Console/Tests/Commands/Compilers/CompilerTest.php
+++ b/src/Opulence/Console/Tests/Commands/Compilers/CompilerTest.php
@@ -38,7 +38,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->compiler = new Compiler();
         $this->commandCollection = new CommandCollection($this->compiler);

--- a/src/Opulence/Console/Tests/KernelTest.php
+++ b/src/Opulence/Console/Tests/KernelTest.php
@@ -42,7 +42,7 @@ class KernelTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->compiler = new CommandCompiler();
         $this->commands = new CommandCollection($this->compiler);

--- a/src/Opulence/Console/Tests/Prompts/PromptTest.php
+++ b/src/Opulence/Console/Tests/Prompts/PromptTest.php
@@ -33,7 +33,7 @@ class PromptTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->response = new Response(new Compiler(new Lexer(), new Parser()));
         $this->paddingFormatter = new PaddingFormatter();

--- a/src/Opulence/Console/Tests/Prompts/Questions/ConfirmationTest.php
+++ b/src/Opulence/Console/Tests/Prompts/Questions/ConfirmationTest.php
@@ -23,7 +23,7 @@ class ConfirmationTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->question = new Confirmation('Is Dave cool (yn)');
     }

--- a/src/Opulence/Console/Tests/Prompts/Questions/MultipleChoiceTest.php
+++ b/src/Opulence/Console/Tests/Prompts/Questions/MultipleChoiceTest.php
@@ -26,7 +26,7 @@ class MultipleChoiceTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->indexedChoiceQuestion = new MultipleChoice('Dummy question', ['foo', 'bar', 'baz']);
         $this->keyedChoiceQuestion = new MultipleChoice('Dummy question', ['a' => 'b', 'c' => 'd', 'e' => 'f']);

--- a/src/Opulence/Console/Tests/Prompts/Questions/QuestionTest.php
+++ b/src/Opulence/Console/Tests/Prompts/Questions/QuestionTest.php
@@ -23,7 +23,7 @@ class QuestionTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->question = new Question('Dummy question', 'foo');
     }

--- a/src/Opulence/Console/Tests/Requests/ArgumentTest.php
+++ b/src/Opulence/Console/Tests/Requests/ArgumentTest.php
@@ -25,7 +25,7 @@ class ArgumentTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->argument = new Argument('foo', ArgumentTypes::OPTIONAL, 'Foo argument', 'bar');
     }

--- a/src/Opulence/Console/Tests/Requests/OptionTest.php
+++ b/src/Opulence/Console/Tests/Requests/OptionTest.php
@@ -25,7 +25,7 @@ class OptionTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->option = new Option('foo', 'f', OptionTypes::OPTIONAL_VALUE, 'Foo option', 'bar');
     }

--- a/src/Opulence/Console/Tests/Requests/Parsers/ArgvParserTest.php
+++ b/src/Opulence/Console/Tests/Requests/Parsers/ArgvParserTest.php
@@ -24,7 +24,7 @@ class ArgvParserTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->parser = new ArgvParser();
     }

--- a/src/Opulence/Console/Tests/Requests/Parsers/ArrayListParserTest.php
+++ b/src/Opulence/Console/Tests/Requests/Parsers/ArrayListParserTest.php
@@ -24,7 +24,7 @@ class ArrayListParserTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->parser = new ArrayListParser();
     }

--- a/src/Opulence/Console/Tests/Requests/Parsers/StringParserTest.php
+++ b/src/Opulence/Console/Tests/Requests/Parsers/StringParserTest.php
@@ -24,7 +24,7 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->parser = new StringParser(new StringTokenizer());
     }

--- a/src/Opulence/Console/Tests/Requests/RequestTest.php
+++ b/src/Opulence/Console/Tests/Requests/RequestTest.php
@@ -24,7 +24,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->request = new Request();
     }

--- a/src/Opulence/Console/Tests/Requests/Tokenizers/ArgvTokenizerTest.php
+++ b/src/Opulence/Console/Tests/Requests/Tokenizers/ArgvTokenizerTest.php
@@ -23,7 +23,7 @@ class ArgvTokenizerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->tokenizer = new ArgvTokenizer();
     }

--- a/src/Opulence/Console/Tests/Requests/Tokenizers/ArrayListTokenizerTest.php
+++ b/src/Opulence/Console/Tests/Requests/Tokenizers/ArrayListTokenizerTest.php
@@ -24,7 +24,7 @@ class ArrayListTokenizerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->tokenizer = new ArrayListTokenizer();
     }

--- a/src/Opulence/Console/Tests/Requests/Tokenizers/StringTokenizerTest.php
+++ b/src/Opulence/Console/Tests/Requests/Tokenizers/StringTokenizerTest.php
@@ -24,7 +24,7 @@ class StringTokenizerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->tokenizer = new StringTokenizer();
     }

--- a/src/Opulence/Console/Tests/Responses/Compilers/CompilerTest.php
+++ b/src/Opulence/Console/Tests/Responses/Compilers/CompilerTest.php
@@ -27,7 +27,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->compiler = new Compiler(new Lexer(), new Parser());
     }

--- a/src/Opulence/Console/Tests/Responses/Compilers/ElementRegistrantTest.php
+++ b/src/Opulence/Console/Tests/Responses/Compilers/ElementRegistrantTest.php
@@ -27,7 +27,7 @@ class ElementRegistrantTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->registrant = new ElementRegistrant();
     }

--- a/src/Opulence/Console/Tests/Responses/Compilers/Lexers/LexerTest.php
+++ b/src/Opulence/Console/Tests/Responses/Compilers/Lexers/LexerTest.php
@@ -26,7 +26,7 @@ class LexerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->lexer = new Lexer();
     }

--- a/src/Opulence/Console/Tests/Responses/Compilers/Lexers/Tokens/TokenTest.php
+++ b/src/Opulence/Console/Tests/Responses/Compilers/Lexers/Tokens/TokenTest.php
@@ -24,7 +24,7 @@ class TokenTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->token = new Token(TokenTypes::T_WORD, 'foo', 24);
     }

--- a/src/Opulence/Console/Tests/Responses/Compilers/Parsers/AbstractSyntaxTreeTest.php
+++ b/src/Opulence/Console/Tests/Responses/Compilers/Parsers/AbstractSyntaxTreeTest.php
@@ -25,7 +25,7 @@ class AbstractSyntaxTreeTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->tree = new AbstractSyntaxTree();
     }

--- a/src/Opulence/Console/Tests/Responses/Compilers/Parsers/ParserTest.php
+++ b/src/Opulence/Console/Tests/Responses/Compilers/Parsers/ParserTest.php
@@ -29,7 +29,7 @@ class ParserTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->parser = new Parser();
     }

--- a/src/Opulence/Console/Tests/Responses/Formatters/CommandFormatterTest.php
+++ b/src/Opulence/Console/Tests/Responses/Formatters/CommandFormatterTest.php
@@ -32,7 +32,7 @@ class CommandFormatterTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->formatter = new CommandFormatter();
         $this->commandCollection = new CommandCollection(new Compiler());

--- a/src/Opulence/Console/Tests/Responses/Formatters/PaddingFormatterTest.php
+++ b/src/Opulence/Console/Tests/Responses/Formatters/PaddingFormatterTest.php
@@ -23,7 +23,7 @@ class PaddingFormatterTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->formatter = new PaddingFormatter();
     }

--- a/src/Opulence/Console/Tests/Responses/Formatters/TableFormatterTest.php
+++ b/src/Opulence/Console/Tests/Responses/Formatters/TableFormatterTest.php
@@ -24,7 +24,7 @@ class TableFormatterTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->formatter = new TableFormatter(new PaddingFormatter());
     }

--- a/src/Opulence/Console/Tests/Responses/ResponseTest.php
+++ b/src/Opulence/Console/Tests/Responses/ResponseTest.php
@@ -26,7 +26,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->response = new Response(new Compiler(new Lexer(), new Parser()));
     }

--- a/src/Opulence/Console/Tests/Responses/SilentResponseTest.php
+++ b/src/Opulence/Console/Tests/Responses/SilentResponseTest.php
@@ -23,7 +23,7 @@ class SilentResponseTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->response = new SilentResponse();
     }

--- a/src/Opulence/Console/Tests/Responses/StreamResponseTest.php
+++ b/src/Opulence/Console/Tests/Responses/StreamResponseTest.php
@@ -29,7 +29,7 @@ class StreamResponseTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->compiler = new Compiler(new Lexer(), new Parser());
         $this->response = new StreamResponse(fopen('php://memory', 'w'), $this->compiler);

--- a/src/Opulence/Cryptography/Tests/Encryption/EncrypterTest.php
+++ b/src/Opulence/Cryptography/Tests/Encryption/EncrypterTest.php
@@ -29,7 +29,7 @@ class EncrypterTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->encrypterWithPassword = new Encrypter(new Password('abcdefghijklmnoq'));
         $this->encrypterWithKey = new Encrypter(new Key(str_repeat('a', 32)));

--- a/src/Opulence/Cryptography/Tests/Encryption/Keys/DerivedKeysTest.php
+++ b/src/Opulence/Cryptography/Tests/Encryption/Keys/DerivedKeysTest.php
@@ -23,7 +23,7 @@ class DerivedKeysTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->derivedKeys = new DerivedKeys(str_repeat('1', 32), str_repeat('2', 32));
     }

--- a/src/Opulence/Cryptography/Tests/Encryption/Keys/Pbkdf2KeyDeriverTest.php
+++ b/src/Opulence/Cryptography/Tests/Encryption/Keys/Pbkdf2KeyDeriverTest.php
@@ -25,7 +25,7 @@ class Pbkdf2KeyDeriverTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->keyDeriver = new Pbkdf2KeyDeriver();
     }

--- a/src/Opulence/Cryptography/Tests/Encryption/Keys/SecretTest.php
+++ b/src/Opulence/Cryptography/Tests/Encryption/Keys/SecretTest.php
@@ -24,7 +24,7 @@ class SecretTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->secret = new Secret(SecretTypes::PASSWORD, 'foo');
     }

--- a/src/Opulence/Cryptography/Tests/Hashing/BcryptHasherTest.php
+++ b/src/Opulence/Cryptography/Tests/Hashing/BcryptHasherTest.php
@@ -23,7 +23,7 @@ class BcryptHasherTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->hasher = new BcryptHasher();
     }

--- a/src/Opulence/Databases/Tests/Adapters/Pdo/ConnectionTest.php
+++ b/src/Opulence/Databases/Tests/Adapters/Pdo/ConnectionTest.php
@@ -29,7 +29,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->provider = new Provider();
         $this->server = new Server();
@@ -39,7 +39,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
     /**
      * Does some housekeeping before ending the tests
      */
-    public function tearDown()
+    protected function tearDown()
     {
         $this->pdo = null;
     }

--- a/src/Opulence/Databases/Tests/ConnectionPools/Strategies/ServerSelection/RandomServerSelectionStrategyTest.php
+++ b/src/Opulence/Databases/Tests/ConnectionPools/Strategies/ServerSelection/RandomServerSelectionStrategyTest.php
@@ -25,7 +25,7 @@ class RandomServerSelectionStrategyTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->strategy = new RandomServerSelectionStrategy();
     }

--- a/src/Opulence/Databases/Tests/ConnectionPools/Strategies/ServerSelection/SingleServerSelectionStrategyTest.php
+++ b/src/Opulence/Databases/Tests/ConnectionPools/Strategies/ServerSelection/SingleServerSelectionStrategyTest.php
@@ -25,7 +25,7 @@ class SingleServerSelectionStrategyTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->strategy = new SingleServerSelectionStrategy();
     }

--- a/src/Opulence/Databases/Tests/Migrations/FileMigrationFinderTest.php
+++ b/src/Opulence/Databases/Tests/Migrations/FileMigrationFinderTest.php
@@ -31,7 +31,7 @@ class FileMigrationFinderTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->migrationFinder = new FileMigrationFinder();
         $topLevelMigrationNamePieces = explode('\\', MigrationA::class);

--- a/src/Opulence/Databases/Tests/Migrations/MigratorTest.php
+++ b/src/Opulence/Databases/Tests/Migrations/MigratorTest.php
@@ -31,7 +31,7 @@ class MigratorTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->connection = $this->createMock(IConnection::class);
         $this->migrationResolver = $this->createMock(IMigrationResolver::class);

--- a/src/Opulence/Databases/Tests/Providers/PostgreSqlProviderTest.php
+++ b/src/Opulence/Databases/Tests/Providers/PostgreSqlProviderTest.php
@@ -23,7 +23,7 @@ class PostgreSqlProviderTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->provider = new PostgreSqlProvider();
     }

--- a/src/Opulence/Databases/Tests/Providers/ProviderTest.php
+++ b/src/Opulence/Databases/Tests/Providers/ProviderTest.php
@@ -23,7 +23,7 @@ class ProviderTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->provider = new Provider();
     }

--- a/src/Opulence/Databases/Tests/Providers/Types/TypeMapperTest.php
+++ b/src/Opulence/Databases/Tests/Providers/Types/TypeMapperTest.php
@@ -30,7 +30,7 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->typeMapperWithNoProvider = new TypeMapper();
         $this->provider = new Provider();

--- a/src/Opulence/Debug/Tests/Errors/Handlers/ErrorHandlerTest.php
+++ b/src/Opulence/Debug/Tests/Errors/Handlers/ErrorHandlerTest.php
@@ -28,7 +28,7 @@ class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->exceptionHandler = $this->getMockBuilder(IExceptionHandler::class)
             ->disableOriginalConstructor()
@@ -39,7 +39,7 @@ class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
     /**
      * Does some housekeeping before ending the tests
      */
-    public function tearDown()
+    protected function tearDown()
     {
         restore_error_handler();
     }

--- a/src/Opulence/Debug/Tests/Exceptions/Handlers/ExceptionHandlerTest.php
+++ b/src/Opulence/Debug/Tests/Exceptions/Handlers/ExceptionHandlerTest.php
@@ -31,7 +31,7 @@ class ExceptionHandlerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->renderer = $this->createMock(IExceptionRenderer::class);
@@ -42,7 +42,7 @@ class ExceptionHandlerTest extends \PHPUnit\Framework\TestCase
     /**
      * Does some housekeeping before ending the tests
      */
-    public function tearDown()
+    protected function tearDown()
     {
         restore_exception_handler();
     }

--- a/src/Opulence/Debug/Tests/Exceptions/Handlers/Http/ExceptionRendererTest.php
+++ b/src/Opulence/Debug/Tests/Exceptions/Handlers/Http/ExceptionRendererTest.php
@@ -49,7 +49,7 @@ namespace Opulence\Debug\Tests\Exceptions\Handlers\Http
         /**
          * Sets up the tests
          */
-        public function setUp()
+        protected function setUp()
         {
             $this->renderer = new MockRenderer(true);
         }

--- a/src/Opulence/Events/Tests/Dispatchers/EventRegistryTest.php
+++ b/src/Opulence/Events/Tests/Dispatchers/EventRegistryTest.php
@@ -29,7 +29,7 @@ class EventRegistryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->eventRegistry = new EventRegistry();
         $this->event = new Event();

--- a/src/Opulence/Events/Tests/Dispatchers/SynchronousEventDispatcherTest.php
+++ b/src/Opulence/Events/Tests/Dispatchers/SynchronousEventDispatcherTest.php
@@ -32,7 +32,7 @@ class SynchronousEventDispatcherTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->eventRegistry = $this->createMock(IEventRegistry::class);
         $this->dispatcher = new SynchronousEventDispatcher($this->eventRegistry);

--- a/src/Opulence/Framework/Console/Testing/PhpUnit/IntegrationTestCase.php
+++ b/src/Opulence/Framework/Console/Testing/PhpUnit/IntegrationTestCase.php
@@ -101,7 +101,7 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->requestParser = new ArrayListParser();
         $this->commandCollection = $this->container->resolve(CommandCollection::class);

--- a/src/Opulence/Framework/Http/Testing/PhpUnit/IntegrationTestCase.php
+++ b/src/Opulence/Framework/Http/Testing/PhpUnit/IntegrationTestCase.php
@@ -141,7 +141,7 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->container->bindInstance(IExceptionHandler::class, $this->getExceptionHandler());
         $this->container->bindInstance(IExceptionRenderer::class, $this->getExceptionRenderer());

--- a/src/Opulence/Framework/Tests/Composer/ComposerTest.php
+++ b/src/Opulence/Framework/Tests/Composer/ComposerTest.php
@@ -49,7 +49,7 @@ class ComposerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->rootPath = realpath(__DIR__ . '/../../../../..');
         $this->psr4RootPath = realpath(__DIR__ . '/../../../../../src');

--- a/src/Opulence/Framework/Tests/Composer/ExecutableTest.php
+++ b/src/Opulence/Framework/Tests/Composer/ExecutableTest.php
@@ -25,7 +25,7 @@ class ExecutableTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->executableWithoutPHAR = new Executable(__DIR__);
         $this->executableWithPHAR = new Executable(__DIR__ . '/Mocks');

--- a/src/Opulence/Framework/Tests/Console/Testing/PhpUnit/Assertions/ResponseAssertionsTest.php
+++ b/src/Opulence/Framework/Tests/Console/Testing/PhpUnit/Assertions/ResponseAssertionsTest.php
@@ -27,7 +27,7 @@ class ResponseAssertionsTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->assertions = new ResponseAssertions();
         $this->mockResponse = $this->getMockBuilder(StreamResponse::class)

--- a/src/Opulence/Framework/Tests/Console/Testing/PhpUnit/CommandBuilderTest.php
+++ b/src/Opulence/Framework/Tests/Console/Testing/PhpUnit/CommandBuilderTest.php
@@ -26,7 +26,7 @@ class CommandBuilderTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->integrationTest = $this->createMock(IntegrationTestCase::class);
         $this->integrationTest->expects($this->any())

--- a/src/Opulence/Framework/Tests/Console/Testing/PhpUnit/IntegrationTestCaseTest.php
+++ b/src/Opulence/Framework/Tests/Console/Testing/PhpUnit/IntegrationTestCaseTest.php
@@ -33,7 +33,7 @@ class IntegrationTestCaseTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->testCase = new MockIntegrationTestCase();
         $this->testCase->setUp();

--- a/src/Opulence/Framework/Tests/Console/Testing/PhpUnit/Mocks/IntegrationTestCase.php
+++ b/src/Opulence/Framework/Tests/Console/Testing/PhpUnit/Mocks/IntegrationTestCase.php
@@ -60,7 +60,7 @@ class IntegrationTestCase extends BaseIntegrationTestCase
     /**
      * Sets up the application and container
      */
-    public function setUp()
+    protected function setUp()
     {
         Config::setCategory('paths', [
             'configs' => realpath(__DIR__ . '/../../configs'),

--- a/src/Opulence/Framework/Tests/Databases/Migrations/ContainerMigrationResolverTest.php
+++ b/src/Opulence/Framework/Tests/Databases/Migrations/ContainerMigrationResolverTest.php
@@ -28,7 +28,7 @@ class ContainerMigrationResolverTest
     /**
      * Sets up tests
      */
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->container = $this->createMock(IContainer::class);
         $this->migrationResolver = new ContainerMigrationResolver($this->container);

--- a/src/Opulence/Framework/Tests/Debug/Exceptions/Handlers/Http/ExceptionRendererTest.php
+++ b/src/Opulence/Framework/Tests/Debug/Exceptions/Handlers/Http/ExceptionRendererTest.php
@@ -36,7 +36,7 @@ class ExceptionRendererTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->viewFactory = $this->createMock(IViewFactory::class);
         $this->viewCompiler = $this->createMock(ICompiler::class);
@@ -49,7 +49,7 @@ class ExceptionRendererTest extends \PHPUnit\Framework\TestCase
     /**
      * Does some housekeeping before ending the tests
      */
-    public function tearDown()
+    protected function tearDown()
     {
         ob_end_clean();
     }

--- a/src/Opulence/Framework/Tests/Http/CsrfTokenCheckerTest.php
+++ b/src/Opulence/Framework/Tests/Http/CsrfTokenCheckerTest.php
@@ -31,7 +31,7 @@ class CsrfTokenCheckerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->checker = new CsrfTokenChecker();
         $this->request = $this->getMockBuilder(Request::class)

--- a/src/Opulence/Framework/Tests/Http/Testing/PhpUnit/Assertions/ResponseAssertionsTest.php
+++ b/src/Opulence/Framework/Tests/Http/Testing/PhpUnit/Assertions/ResponseAssertionsTest.php
@@ -29,7 +29,7 @@ class ResponseAssertionsTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->assertions = new ResponseAssertions();
     }

--- a/src/Opulence/Framework/Tests/Http/Testing/PhpUnit/Assertions/ViewAssertionsTest.php
+++ b/src/Opulence/Framework/Tests/Http/Testing/PhpUnit/Assertions/ViewAssertionsTest.php
@@ -29,7 +29,7 @@ class ViewAssertionsTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->assertions = new ViewAssertions();
         $this->mockView = $this->createMock(IView::class);

--- a/src/Opulence/Framework/Tests/Http/Testing/PhpUnit/IntegrationTestCaseTest.php
+++ b/src/Opulence/Framework/Tests/Http/Testing/PhpUnit/IntegrationTestCaseTest.php
@@ -24,7 +24,7 @@ class IntegrationTestCaseTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->integrationTest = new MockIntegrationTestCase();
         $this->integrationTest->setUp();

--- a/src/Opulence/Framework/Tests/Http/Testing/PhpUnit/Mocks/IntegrationTestCase.php
+++ b/src/Opulence/Framework/Tests/Http/Testing/PhpUnit/Mocks/IntegrationTestCase.php
@@ -70,7 +70,7 @@ class IntegrationTestCase extends BaseIntegrationTestCase
     /**
      * Sets up the application and container
      */
-    public function setUp()
+    protected function setUp()
     {
         Config::setCategory('paths', [
             'configs' => realpath(__DIR__ . '/../../configs'),

--- a/src/Opulence/Framework/Tests/Http/Testing/PhpUnit/RequestBuilderTest.php
+++ b/src/Opulence/Framework/Tests/Http/Testing/PhpUnit/RequestBuilderTest.php
@@ -27,7 +27,7 @@ class RequestBuilderTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->integrationTest = $this->createMock(IntegrationTestCase::class);
     }

--- a/src/Opulence/Framework/Tests/Views/Caching/GenericCacheTest.php
+++ b/src/Opulence/Framework/Tests/Views/Caching/GenericCacheTest.php
@@ -29,7 +29,7 @@ class GenericCacheTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->bridge = $this->createMock(ICacheBridge::class);
         $this->cache = new GenericCache($this->bridge, 3600);

--- a/src/Opulence/Http/Tests/CollectionTest.php
+++ b/src/Opulence/Http/Tests/CollectionTest.php
@@ -23,7 +23,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->parameters = new Collection([]);
     }

--- a/src/Opulence/Http/Tests/HeadersTest.php
+++ b/src/Opulence/Http/Tests/HeadersTest.php
@@ -23,7 +23,7 @@ class HeadersTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->headers = new Headers();
     }

--- a/src/Opulence/Http/Tests/HttpExceptionTest.php
+++ b/src/Opulence/Http/Tests/HttpExceptionTest.php
@@ -26,7 +26,7 @@ class HttpExceptionTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->previousException = new Exception();
         $this->exception = new HttpException(

--- a/src/Opulence/Http/Tests/Requests/RequestHeadersTest.php
+++ b/src/Opulence/Http/Tests/Requests/RequestHeadersTest.php
@@ -37,7 +37,7 @@ class RequestHeadersTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->headers = new RequestHeaders($this->serverArray);
     }

--- a/src/Opulence/Http/Tests/Requests/RequestTest.php
+++ b/src/Opulence/Http/Tests/Requests/RequestTest.php
@@ -51,7 +51,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->request = new Request($_GET, $_POST, $_COOKIE, $_SERVER, $_FILES, $_ENV);
     }
@@ -59,7 +59,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     /**
      * Does some housekeeping before ending the tests
      */
-    public function tearDown()
+    protected function tearDown()
     {
         $_COOKIE = self::$cookieClone;
         $_SERVER = self::$serverClone;

--- a/src/Opulence/Http/Tests/Requests/UploadedFileTest.php
+++ b/src/Opulence/Http/Tests/Requests/UploadedFileTest.php
@@ -44,7 +44,7 @@ class UploadedFileTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->file = new MockUploadedFile(
             __DIR__ . self::UPLOADED_FILE_FILENAME,

--- a/src/Opulence/Http/Tests/Responses/CookieTest.php
+++ b/src/Opulence/Http/Tests/Responses/CookieTest.php
@@ -38,7 +38,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->name = 'foo';
         $this->value = 'bar';

--- a/src/Opulence/Http/Tests/Responses/RedirectResponseTest.php
+++ b/src/Opulence/Http/Tests/Responses/RedirectResponseTest.php
@@ -24,7 +24,7 @@ class RedirectResponseTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->redirectResponse = new RedirectResponse('/foo', ResponseHeaders::HTTP_ACCEPTED, ['FOO' => 'bar']);
     }

--- a/src/Opulence/Http/Tests/Responses/ResponseHeadersTest.php
+++ b/src/Opulence/Http/Tests/Responses/ResponseHeadersTest.php
@@ -25,7 +25,7 @@ class ResponseHeadersTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->headers = new ResponseHeaders();
     }

--- a/src/Opulence/Http/Tests/Responses/ResponseTest.php
+++ b/src/Opulence/Http/Tests/Responses/ResponseTest.php
@@ -25,7 +25,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->response = new Response();
     }

--- a/src/Opulence/IO/Tests/FileSystemTest.php
+++ b/src/Opulence/IO/Tests/FileSystemTest.php
@@ -25,7 +25,7 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->fileSystem = new FileSystem();
     }
@@ -33,7 +33,7 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase
     /**
      * Does some housekeeping before ending the tests
      */
-    public function tearDown()
+    protected function tearDown()
     {
         @unlink(__DIR__ . '/test.txt');
     }

--- a/src/Opulence/IO/Tests/Streams/MultiStreamTest.php
+++ b/src/Opulence/IO/Tests/Streams/MultiStreamTest.php
@@ -27,7 +27,7 @@ class MultiStreamTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->multiStream = new MultiStream();
     }

--- a/src/Opulence/IO/Tests/Streams/StreamTest.php
+++ b/src/Opulence/IO/Tests/Streams/StreamTest.php
@@ -22,7 +22,7 @@ class StreamTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleans up the tests
      */
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         if (file_exists(self::TEMP_FILE)) {
             @unlink(self::TEMP_FILE);

--- a/src/Opulence/Ioc/Tests/Bootstrappers/BootstrapperRegistryTest.php
+++ b/src/Opulence/Ioc/Tests/Bootstrappers/BootstrapperRegistryTest.php
@@ -27,7 +27,7 @@ class BootstrapperRegistryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->registry = new BootstrapperRegistry();
     }

--- a/src/Opulence/Ioc/Tests/Bootstrappers/BootstrapperResolverTest.php
+++ b/src/Opulence/Ioc/Tests/Bootstrappers/BootstrapperResolverTest.php
@@ -26,7 +26,7 @@ class BootstrapperResolverTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->resolver = new BootstrapperResolver();
     }

--- a/src/Opulence/Ioc/Tests/Bootstrappers/BootstrapperTest.php
+++ b/src/Opulence/Ioc/Tests/Bootstrappers/BootstrapperTest.php
@@ -24,7 +24,7 @@ class BootstrapperTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->bootstrapper = new Bootstrapper();
     }

--- a/src/Opulence/Ioc/Tests/Bootstrappers/Caching/FileCacheTest.php
+++ b/src/Opulence/Ioc/Tests/Bootstrappers/Caching/FileCacheTest.php
@@ -65,7 +65,7 @@ class FileCacheTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->cachedRegistryFilePath = __DIR__ . '/files/cachedRegistry.json';
         $this->cache = new FileCache($this->cachedRegistryFilePath);
@@ -75,7 +75,7 @@ class FileCacheTest extends \PHPUnit\Framework\TestCase
     /**
      * Tears down the tests
      */
-    public function tearDown()
+    protected function tearDown()
     {
         if (file_exists($this->cachedRegistryFilePath)) {
             @unlink($this->cachedRegistryFilePath);

--- a/src/Opulence/Ioc/Tests/Bootstrappers/Dispatchers/BootstrapperDispatcherTest.php
+++ b/src/Opulence/Ioc/Tests/Bootstrappers/Dispatchers/BootstrapperDispatcherTest.php
@@ -43,7 +43,7 @@ class BootstrapperDispatcherTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->container = new Container();
         $this->bootstrapperRegistry = new BootstrapperRegistry();

--- a/src/Opulence/Ioc/Tests/Bootstrappers/Factories/BootstrapperRegistryFactoryTest.php
+++ b/src/Opulence/Ioc/Tests/Bootstrappers/Factories/BootstrapperRegistryFactoryTest.php
@@ -29,7 +29,7 @@ class BootstrapperRegistryFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->resolver = $this->createMock(IBootstrapperResolver::class);
         $this->factory = new BootstrapperRegistryFactory($this->resolver);

--- a/src/Opulence/Ioc/Tests/Bootstrappers/Factories/CachedBootstrapperRegistryFactoryTest.php
+++ b/src/Opulence/Ioc/Tests/Bootstrappers/Factories/CachedBootstrapperRegistryFactoryTest.php
@@ -34,7 +34,7 @@ class CachedBootstrapperRegistryFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->resolver = $this->createMock(IBootstrapperResolver::class);
         $this->cache = $this->createMock(ICache::class);

--- a/src/Opulence/Ioc/Tests/ClassBindingTest.php
+++ b/src/Opulence/Ioc/Tests/ClassBindingTest.php
@@ -23,7 +23,7 @@ class ClassBindingTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->binding = new ClassBinding('foo', ['bar'], false);
     }

--- a/src/Opulence/Ioc/Tests/ContainerTest.php
+++ b/src/Opulence/Ioc/Tests/ContainerTest.php
@@ -67,7 +67,7 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->container = new Container();
     }

--- a/src/Opulence/Memcached/Tests/Types/TypeMapperTest.php
+++ b/src/Opulence/Memcached/Tests/Types/TypeMapperTest.php
@@ -25,7 +25,7 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->typeMapper = new TypeMapper();
     }

--- a/src/Opulence/Orm/Tests/ChangeTracking/ChangeTrackerTest.php
+++ b/src/Opulence/Orm/Tests/ChangeTracking/ChangeTrackerTest.php
@@ -29,7 +29,7 @@ class ChangeTrackerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->changeTracker = new ChangeTracker();
         /**

--- a/src/Opulence/Orm/Tests/DataMappers/CachedSqlDataMapperTest.php
+++ b/src/Opulence/Orm/Tests/DataMappers/CachedSqlDataMapperTest.php
@@ -36,7 +36,7 @@ class CachedSqlDataMapperTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $idAccessorRegistry = new IdAccessorRegistry();
         $idAccessorRegistry->registerIdAccessors(User::class, function ($user) {

--- a/src/Opulence/Orm/Tests/EntityRegistryTest.php
+++ b/src/Opulence/Orm/Tests/EntityRegistryTest.php
@@ -41,7 +41,7 @@ class EntityRegistryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $idAccessorRegistry = new IdAccessorRegistry();
         $idAccessorRegistry->registerIdAccessors(

--- a/src/Opulence/Orm/Tests/Ids/Accessors/IdAccessorRegistryTest.php
+++ b/src/Opulence/Orm/Tests/Ids/Accessors/IdAccessorRegistryTest.php
@@ -30,7 +30,7 @@ class IdAccessorRegistryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->registry = new IdAccessorRegistry();
         $this->registry->registerIdAccessors(

--- a/src/Opulence/Orm/Tests/Ids/Generators/IdGeneratorRegistryTest.php
+++ b/src/Opulence/Orm/Tests/Ids/Generators/IdGeneratorRegistryTest.php
@@ -24,7 +24,7 @@ class IdGeneratorRegistryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->registry = new IdGeneratorRegistry();
     }

--- a/src/Opulence/Orm/Tests/Repositories/RepositoryTest.php
+++ b/src/Opulence/Orm/Tests/Repositories/RepositoryTest.php
@@ -42,7 +42,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $idAccessorRegistry = new IdAccessorRegistry();
         $idAccessorRegistry->registerIdAccessors(

--- a/src/Opulence/Orm/Tests/UnitOfWorkTest.php
+++ b/src/Opulence/Orm/Tests/UnitOfWorkTest.php
@@ -46,7 +46,7 @@ class UnitOfWorkTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $idAccessorRegistry = new IdAccessorRegistry();
         $idAccessorRegistry->registerIdAccessors(

--- a/src/Opulence/Pipelines/Tests/PipelineTest.php
+++ b/src/Opulence/Pipelines/Tests/PipelineTest.php
@@ -26,7 +26,7 @@ class PipelineTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->pipeline = new Pipeline();
     }

--- a/src/Opulence/QueryBuilders/Tests/Conditions/ConditionFactoryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/Conditions/ConditionFactoryTest.php
@@ -27,7 +27,7 @@ class ConditionFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->conditionFactory = new ConditionFactory();
     }

--- a/src/Opulence/QueryBuilders/Tests/DeleteQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/DeleteQueryTest.php
@@ -25,7 +25,7 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->condition = $this->createMock(ICondition::class);
         $this->condition->expects($this->any())

--- a/src/Opulence/QueryBuilders/Tests/QueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/QueryTest.php
@@ -25,7 +25,7 @@ class QueryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the test
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->query = $this->getMockForAbstractClass(Query::class);
     }

--- a/src/Opulence/QueryBuilders/Tests/SelectQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/SelectQueryTest.php
@@ -25,7 +25,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->condition = $this->createMock(ICondition::class);
         $this->condition->expects($this->any())

--- a/src/Opulence/QueryBuilders/Tests/UpdateQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/UpdateQueryTest.php
@@ -26,7 +26,7 @@ class UpdateQueryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->condition = $this->createMock(ICondition::class);
         $this->condition->expects($this->any())

--- a/src/Opulence/Redis/Tests/Types/TypeMapperTest.php
+++ b/src/Opulence/Redis/Tests/Types/TypeMapperTest.php
@@ -25,7 +25,7 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->typeMapper = new TypeMapper();
     }

--- a/src/Opulence/Routing/Tests/ControllerTest.php
+++ b/src/Opulence/Routing/Tests/ControllerTest.php
@@ -24,7 +24,7 @@ class ControllerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->controller = new Controller();
         $this->controller->setRequest(Request::createFromGlobals());

--- a/src/Opulence/Routing/Tests/Dispatchers/ContainerDependencyResolverTest.php
+++ b/src/Opulence/Routing/Tests/Dispatchers/ContainerDependencyResolverTest.php
@@ -28,7 +28,7 @@ class ContainerDependencyResolverTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->container = $this->createMock(IContainer::class);
         $this->dependencyResolver = new ContainerDependencyResolver($this->container);

--- a/src/Opulence/Routing/Tests/Dispatchers/MiddlewarePipelineTest.php
+++ b/src/Opulence/Routing/Tests/Dispatchers/MiddlewarePipelineTest.php
@@ -27,7 +27,7 @@ class MiddlewarePipelineTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->middlewarePipeline = new MiddlewarePipeline();
     }

--- a/src/Opulence/Routing/Tests/Dispatchers/RouteDispatcherTest.php
+++ b/src/Opulence/Routing/Tests/Dispatchers/RouteDispatcherTest.php
@@ -46,7 +46,7 @@ class RouteDispatcherTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->dependencyResolver = $this->createMock(IDependencyResolver::class);
         $this->dependencyResolver->expects($this->any())

--- a/src/Opulence/Routing/Tests/Middleware/MiddlewareParametersTest.php
+++ b/src/Opulence/Routing/Tests/Middleware/MiddlewareParametersTest.php
@@ -23,7 +23,7 @@ class MiddlewareParametersTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->parameters = new MiddlewareParameters('foo', ['bar' => 'baz']);
     }

--- a/src/Opulence/Routing/Tests/Middleware/ParameterizedMiddlewareTest.php
+++ b/src/Opulence/Routing/Tests/Middleware/ParameterizedMiddlewareTest.php
@@ -24,7 +24,7 @@ class ParameterizedMiddlewareTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->middleware = new ParameterizedMiddlewareMock();
     }

--- a/src/Opulence/Routing/Tests/RouterTest.php
+++ b/src/Opulence/Routing/Tests/RouterTest.php
@@ -46,7 +46,7 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         /** @var IDependencyResolver|\PHPUnit_Framework_MockObject_MockObject $dependencyResolver */
         $dependencyResolver = $this->createMock(IDependencyResolver::class);

--- a/src/Opulence/Routing/Tests/Routes/Caching/FileCacheTest.php
+++ b/src/Opulence/Routing/Tests/Routes/Caching/FileCacheTest.php
@@ -33,7 +33,7 @@ class FileCacheTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->cache = new FileCache();
         $this->cachedRouteFilePath = __DIR__ . '/files/' . FileCache::DEFAULT_CACHED_ROUTES_FILE_NAME;
@@ -43,7 +43,7 @@ class FileCacheTest extends \PHPUnit\Framework\TestCase
     /**
      * Tears down the tests
      */
-    public function tearDown()
+    protected function tearDown()
     {
         if (file_exists($this->cachedRouteFilePath)) {
             @unlink($this->cachedRouteFilePath);

--- a/src/Opulence/Routing/Tests/Routes/CompiledRouteTest.php
+++ b/src/Opulence/Routing/Tests/Routes/CompiledRouteTest.php
@@ -27,7 +27,7 @@ class CompiledRouteTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->parsedRoute = new ParsedRoute(new Route('GET', '/', 'foo@bar'));
         $this->compiledRoute = new CompiledRoute($this->parsedRoute, true, ['foo' => 'bar']);

--- a/src/Opulence/Routing/Tests/Routes/Compilers/CompilerTest.php
+++ b/src/Opulence/Routing/Tests/Routes/Compilers/CompilerTest.php
@@ -29,7 +29,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $routeMatchers = [
             new PathMatcher(),

--- a/src/Opulence/Routing/Tests/Routes/Compilers/Matchers/HostMatcherTest.php
+++ b/src/Opulence/Routing/Tests/Routes/Compilers/Matchers/HostMatcherTest.php
@@ -30,7 +30,7 @@ class HostMatcherTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->matcher = new HostMatcher();
         $this->request = $this->getMockBuilder(Request::class)

--- a/src/Opulence/Routing/Tests/Routes/Compilers/Matchers/PathMatcherTest.php
+++ b/src/Opulence/Routing/Tests/Routes/Compilers/Matchers/PathMatcherTest.php
@@ -29,7 +29,7 @@ class PathMatcherTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->matcher = new PathMatcher();
         $this->request = $this->getMockBuilder(Request::class)

--- a/src/Opulence/Routing/Tests/Routes/Compilers/Matchers/SchemeMatcherTest.php
+++ b/src/Opulence/Routing/Tests/Routes/Compilers/Matchers/SchemeMatcherTest.php
@@ -29,7 +29,7 @@ class SchemeMatcherTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->matcher = new SchemeMatcher();
         $this->request = $this->getMockBuilder(Request::class)

--- a/src/Opulence/Routing/Tests/Routes/Compilers/Parsers/ParserTest.php
+++ b/src/Opulence/Routing/Tests/Routes/Compilers/Parsers/ParserTest.php
@@ -26,7 +26,7 @@ class ParserTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->parser = new Parser();
     }

--- a/src/Opulence/Routing/Tests/Routes/RouteCollectionTest.php
+++ b/src/Opulence/Routing/Tests/Routes/RouteCollectionTest.php
@@ -28,7 +28,7 @@ class RouteCollectionTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->collection = new RouteCollection();
     }

--- a/src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php
+++ b/src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php
@@ -28,7 +28,7 @@ class UrlGeneratorTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $namedRoutes = [
             new Route(

--- a/src/Opulence/Sessions/Tests/Handlers/ArraySessionHandlerTest.php
+++ b/src/Opulence/Sessions/Tests/Handlers/ArraySessionHandlerTest.php
@@ -23,7 +23,7 @@ class ArraySessionHandlerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->handler = new ArraySessionHandler();
     }

--- a/src/Opulence/Sessions/Tests/Handlers/CacheSessionHandlerTest.php
+++ b/src/Opulence/Sessions/Tests/Handlers/CacheSessionHandlerTest.php
@@ -26,7 +26,7 @@ class CacheSessionHandlerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->bridge = $this->createMock(ICacheBridge::class);
         $this->handler = new CacheSessionHandler($this->bridge, 123);

--- a/src/Opulence/Sessions/Tests/Handlers/FileSessionHandlerTest.php
+++ b/src/Opulence/Sessions/Tests/Handlers/FileSessionHandlerTest.php
@@ -52,7 +52,7 @@ class FileSessionHandlerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->fileSystem = new FileSystem();
         $this->handler = new FileSessionHandler(__DIR__ . '/' . self::$path);
@@ -61,7 +61,7 @@ class FileSessionHandlerTest extends \PHPUnit\Framework\TestCase
     /**
      * Does some housekeeping before ending the tests
      */
-    public function tearDown()
+    protected function tearDown()
     {
         @unlink(__DIR__ . '/' . self::$path . '/foo');
         @unlink(__DIR__ . '/' . self::$path . '/bar');

--- a/src/Opulence/Sessions/Tests/Handlers/SessionEncrypterTest.php
+++ b/src/Opulence/Sessions/Tests/Handlers/SessionEncrypterTest.php
@@ -28,7 +28,7 @@ class SessionEncrypterTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->opulenceEncrypter = $this->createMock(IEncrypter::class);
         $this->sessionEncrypter = new SessionEncrypter($this->opulenceEncrypter);

--- a/src/Opulence/Sessions/Tests/Handlers/SessionHandlerTest.php
+++ b/src/Opulence/Sessions/Tests/Handlers/SessionHandlerTest.php
@@ -28,7 +28,7 @@ class SessionHandlerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->handler = $this->getMockForAbstractClass(SessionHandler::class);
         $this->encrypter = $this->createMock(ISessionEncrypter::class);

--- a/src/Opulence/Sessions/Tests/Ids/Generators/IdGeneratorTest.php
+++ b/src/Opulence/Sessions/Tests/Ids/Generators/IdGeneratorTest.php
@@ -23,7 +23,7 @@ class IdGeneratorTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->generator = new IdGenerator();
     }

--- a/src/Opulence/Validation/Tests/Factories/ValidatorFactoryTest.php
+++ b/src/Opulence/Validation/Tests/Factories/ValidatorFactoryTest.php
@@ -27,7 +27,7 @@ class ValidatorFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->rulesFactory = $this->getMockBuilder(RulesFactory::class)
             ->disableOriginalConstructor()

--- a/src/Opulence/Validation/Tests/Rules/Errors/Compilers/CompilerTest.php
+++ b/src/Opulence/Validation/Tests/Rules/Errors/Compilers/CompilerTest.php
@@ -23,7 +23,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->compiler = new Compiler();
     }

--- a/src/Opulence/Validation/Tests/Rules/Errors/ErrorCollectionTest.php
+++ b/src/Opulence/Validation/Tests/Rules/Errors/ErrorCollectionTest.php
@@ -23,7 +23,7 @@ class ErrorCollectionTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->collection = new ErrorCollection();
     }

--- a/src/Opulence/Validation/Tests/Rules/Errors/ErrorTemplateRegistryTest.php
+++ b/src/Opulence/Validation/Tests/Rules/Errors/ErrorTemplateRegistryTest.php
@@ -24,7 +24,7 @@ class ErrorTemplateRegistryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->registry = new ErrorTemplateRegistry();
     }

--- a/src/Opulence/Validation/Tests/Rules/Models/ModelStateTest.php
+++ b/src/Opulence/Validation/Tests/Rules/Models/ModelStateTest.php
@@ -32,7 +32,7 @@ class ModelStateTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->rules = $this->getMockBuilder(Rules::class)
             ->disableOriginalConstructor()

--- a/src/Opulence/Validation/Tests/Rules/RuleExtensionRegistryTest.php
+++ b/src/Opulence/Validation/Tests/Rules/RuleExtensionRegistryTest.php
@@ -26,7 +26,7 @@ class RuleExtensionRegistryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->registry = new RuleExtensionRegistry();
     }

--- a/src/Opulence/Validation/Tests/Rules/RulesTest.php
+++ b/src/Opulence/Validation/Tests/Rules/RulesTest.php
@@ -38,7 +38,7 @@ class RulesTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->ruleExtensionRegistry = $this->createMock(RuleExtensionRegistry::class);
         $this->errorTemplateRegistry = $this->createMock(ErrorTemplateRegistry::class);

--- a/src/Opulence/Validation/Tests/ValidatorTest.php
+++ b/src/Opulence/Validation/Tests/ValidatorTest.php
@@ -38,7 +38,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->ruleExtensionRegistry = $this->createMock(RuleExtensionRegistry::class);
         /** @var ErrorTemplateRegistry|\PHPUnit_Framework_MockObject_MockObject $errorTemplateRegistry */

--- a/src/Opulence/Views/Tests/Caching/ArrayCacheTest.php
+++ b/src/Opulence/Views/Tests/Caching/ArrayCacheTest.php
@@ -26,7 +26,7 @@ class ArrayCacheTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->cache = new ArrayCache();
         $this->view = $this->createMock(IView::class);

--- a/src/Opulence/Views/Tests/Caching/FileCacheTest.php
+++ b/src/Opulence/Views/Tests/Caching/FileCacheTest.php
@@ -54,7 +54,7 @@ class FileCacheTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->fileSystem = new FileSystem();
         $this->cache = new FileCache(__DIR__ . '/tmp', 3600);

--- a/src/Opulence/Views/Tests/Compilers/CompilerRegistryTest.php
+++ b/src/Opulence/Views/Tests/Compilers/CompilerRegistryTest.php
@@ -26,7 +26,7 @@ class CompilerRegistryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->registry = new CompilerRegistry();
     }

--- a/src/Opulence/Views/Tests/Compilers/CompilerTest.php
+++ b/src/Opulence/Views/Tests/Compilers/CompilerTest.php
@@ -28,7 +28,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->registry = $this->createMock(ICompilerRegistry::class);
         $this->compiler = new Compiler($this->registry);

--- a/src/Opulence/Views/Tests/Compilers/Fortune/DirectiveTranspilerRegistrantTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Fortune/DirectiveTranspilerRegistrantTest.php
@@ -33,7 +33,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->view = new View();
         $this->registrant = new DirectiveTranspilerRegistrant();

--- a/src/Opulence/Views/Tests/Compilers/Fortune/FortuneCompilerTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Fortune/FortuneCompilerTest.php
@@ -39,7 +39,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         /** @var ICompilerRegistry|\PHPUnit_Framework_MockObject_MockObject $registry */
         $registry = $this->createMock(ICompilerRegistry::class);

--- a/src/Opulence/Views/Tests/Compilers/Fortune/Lexers/LexerTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Fortune/Lexers/LexerTest.php
@@ -29,7 +29,7 @@ class LexerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->lexer = new Lexer();
         $this->view = $this->getMockBuilder(View::class)

--- a/src/Opulence/Views/Tests/Compilers/Fortune/Lexers/Tokens/TokenTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Fortune/Lexers/Tokens/TokenTest.php
@@ -24,7 +24,7 @@ class TokenTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->token = new Token(TokenTypes::T_EXPRESSION, 'foo', 1);
     }

--- a/src/Opulence/Views/Tests/Compilers/Fortune/Parsers/AbstractSyntaxTreeTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Fortune/Parsers/AbstractSyntaxTreeTest.php
@@ -25,7 +25,7 @@ class AbstractSyntaxTreeTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->tree = new AbstractSyntaxTree();
     }

--- a/src/Opulence/Views/Tests/Compilers/Fortune/Parsers/ParserTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Fortune/Parsers/ParserTest.php
@@ -35,7 +35,7 @@ class ParserTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->parser = new Parser();
         $this->ast = new AbstractSyntaxTree();

--- a/src/Opulence/Views/Tests/Compilers/Fortune/TranspilerTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Fortune/TranspilerTest.php
@@ -51,7 +51,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->lexer = $this->createMock(ILexer::class);
         $this->parser = $this->createMock(IParser::class);

--- a/src/Opulence/Views/Tests/Compilers/Fortune/ViewFunctionRegistrantTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Fortune/ViewFunctionRegistrantTest.php
@@ -27,7 +27,7 @@ class ViewFunctionRegistrantTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $xssFilter = new XssFilter();
         /** @var ICache|\PHPUnit_Framework_MockObject_MockObject $cache */

--- a/src/Opulence/Views/Tests/Compilers/Php/PhpCompilerTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Php/PhpCompilerTest.php
@@ -26,7 +26,7 @@ class PhpCompilerTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->compiler = new PhpCompiler();
     }

--- a/src/Opulence/Views/Tests/Factories/IO/FileViewNameResolverTest.php
+++ b/src/Opulence/Views/Tests/Factories/IO/FileViewNameResolverTest.php
@@ -92,7 +92,7 @@ class FileViewNameResolverTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->resolver = new FileViewNameResolver();
     }

--- a/src/Opulence/Views/Tests/Factories/IO/FileViewReaderTest.php
+++ b/src/Opulence/Views/Tests/Factories/IO/FileViewReaderTest.php
@@ -24,7 +24,7 @@ class FileViewReaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->reader = new FileViewReader();
     }

--- a/src/Opulence/Views/Tests/Factories/ViewFactoryTest.php
+++ b/src/Opulence/Views/Tests/Factories/ViewFactoryTest.php
@@ -33,7 +33,7 @@ class ViewFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->viewNameResolver = $this->createMock(IViewNameResolver::class);
         $this->viewReader = $this->createMock(IViewReader::class);

--- a/src/Opulence/Views/Tests/ViewTest.php
+++ b/src/Opulence/Views/Tests/ViewTest.php
@@ -32,7 +32,7 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     /**
      * Sets up the tests
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->view = new View();
         $this->fileSystem = new FileSystem();


### PR DESCRIPTION
# Changed log
- According to the [PHPUnit fixture reference](https://phpunit.readthedocs.io/en/8.5/fixtures.html?highlight=fixtures), the `setUp` method should be `protected`.