### PR TITLE
Using assertSame to make assertEquals strict

### DIFF
--- a/src/Opulence/Applications/Tests/ApplicationTest.php
+++ b/src/Opulence/Applications/Tests/ApplicationTest.php
@@ -175,7 +175,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     public function testGettingCustomVersion()
     {
         $application = new Application($this->createMock(ITaskDispatcher::class), 'foo');
-        $this->assertEquals('foo', $application->getVersion());
+        $this->assertSame('foo', $application->getVersion());
     }
 
     /**
@@ -316,7 +316,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->application->shutDown(function () use (&$shutdownValue) {
             $shutdownValue = 'baz';
         }));
-        $this->assertEquals('baz', $shutdownValue);
+        $this->assertSame('baz', $shutdownValue);
     }
 
     /**
@@ -334,7 +334,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->application->start(function () use (&$startValue) {
             $startValue = 'baz';
         }));
-        $this->assertEquals('baz', $startValue);
+        $this->assertSame('baz', $startValue);
     }
 
     /**
@@ -343,7 +343,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     public function testShutdownTaskThatReturnsSomething()
     {
         $this->application->start();
-        $this->assertEquals('foo', $this->application->shutDown(function () {
+        $this->assertSame('foo', $this->application->shutDown(function () {
             return 'foo';
         }));
     }
@@ -353,7 +353,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
      */
     public function testStartTaskThatReturnsSomething()
     {
-        $this->assertEquals('foo', $this->application->start(function () {
+        $this->assertSame('foo', $this->application->start(function () {
             return 'foo';
         }));
     }

--- a/src/Opulence/Applications/Tests/Tasks/Dispatchers/TaskDispatcherTest.php
+++ b/src/Opulence/Applications/Tests/Tasks/Dispatchers/TaskDispatcherTest.php
@@ -36,7 +36,7 @@ class TaskDispatcherTest extends \PHPUnit\Framework\TestCase
             $value = 'foo';
         });
         $this->dispatcher->dispatch('foo');
-        $this->assertEquals('foo', $value);
+        $this->assertSame('foo', $value);
     }
 
     /**
@@ -49,7 +49,7 @@ class TaskDispatcherTest extends \PHPUnit\Framework\TestCase
             $value = 'foo';
         });
         $this->dispatcher->dispatch(TaskTypes::POST_SHUTDOWN);
-        $this->assertEquals('foo', $value);
+        $this->assertSame('foo', $value);
     }
 
     /**
@@ -62,7 +62,7 @@ class TaskDispatcherTest extends \PHPUnit\Framework\TestCase
             $value = 'foo';
         });
         $this->dispatcher->dispatch(TaskTypes::POST_START);
-        $this->assertEquals('foo', $value);
+        $this->assertSame('foo', $value);
     }
 
     /**
@@ -75,7 +75,7 @@ class TaskDispatcherTest extends \PHPUnit\Framework\TestCase
             $value = 'foo';
         });
         $this->dispatcher->dispatch(TaskTypes::PRE_SHUTDOWN);
-        $this->assertEquals('foo', $value);
+        $this->assertSame('foo', $value);
     }
 
     /**
@@ -88,6 +88,6 @@ class TaskDispatcherTest extends \PHPUnit\Framework\TestCase
             $value = 'foo';
         });
         $this->dispatcher->dispatch(TaskTypes::PRE_START);
-        $this->assertEquals('foo', $value);
+        $this->assertSame('foo', $value);
     }
 }

--- a/src/Opulence/Authentication/Tests/AuthenticationContextTest.php
+++ b/src/Opulence/Authentication/Tests/AuthenticationContextTest.php
@@ -47,7 +47,7 @@ class AuthenticationContextTest extends \PHPUnit\Framework\TestCase
     public function testSettingStatusInConstructor()
     {
         $context = new AuthenticationContext(null, 'foo');
-        $this->assertEquals('foo', $context->getStatus());
+        $this->assertSame('foo', $context->getStatus());
     }
 
     /**
@@ -56,7 +56,7 @@ class AuthenticationContextTest extends \PHPUnit\Framework\TestCase
     public function testSettingStatusInSetter()
     {
         $this->context->setStatus('foo');
-        $this->assertEquals('foo', $this->context->getStatus());
+        $this->assertSame('foo', $this->context->getStatus());
     }
 
     /**

--- a/src/Opulence/Authentication/Tests/Clients/ClientTest.php
+++ b/src/Opulence/Authentication/Tests/Clients/ClientTest.php
@@ -33,7 +33,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingId()
     {
-        $this->assertEquals(123, $this->client->getId());
+        $this->assertSame(123, $this->client->getId());
     }
 
     /**
@@ -41,7 +41,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingName()
     {
-        $this->assertEquals('foo', $this->client->getName());
+        $this->assertSame('foo', $this->client->getName());
     }
 
     /**
@@ -49,7 +49,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingSecret()
     {
-        $this->assertEquals('bar', $this->client->getSecret());
+        $this->assertSame('bar', $this->client->getSecret());
     }
 
     /**
@@ -58,7 +58,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     public function testSettingId()
     {
         $this->client->setId('new');
-        $this->assertEquals('new', $this->client->getId());
+        $this->assertSame('new', $this->client->getId());
     }
 
     /**
@@ -67,6 +67,6 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     public function testSettingName()
     {
         $this->client->setName('new');
-        $this->assertEquals('new', $this->client->getName());
+        $this->assertSame('new', $this->client->getName());
     }
 }

--- a/src/Opulence/Authentication/Tests/Credentials/Authenticators/JwtAuthenticatorTest.php
+++ b/src/Opulence/Authentication/Tests/Credentials/Authenticators/JwtAuthenticatorTest.php
@@ -77,7 +77,7 @@ class JwtAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $subject = null;
         $error = null;
         $this->assertFalse($this->authenticator->authenticate($credential, $subject, $error));
-        $this->assertEquals(AuthenticatorErrorTypes::CREDENTIAL_MISSING, $error);
+        $this->assertSame(AuthenticatorErrorTypes::CREDENTIAL_MISSING, $error);
     }
 
     /**
@@ -92,7 +92,7 @@ class JwtAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $subject = null;
         $error = null;
         $this->assertFalse($this->authenticator->authenticate($this->credential, $subject, $error));
-        $this->assertEquals(AuthenticatorErrorTypes::CREDENTIAL_INCORRECT, $error);
+        $this->assertSame(AuthenticatorErrorTypes::CREDENTIAL_INCORRECT, $error);
     }
 
     /**
@@ -108,7 +108,7 @@ class JwtAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->authenticator->authenticate($this->credential, $subject));
         /** @var ISubject $subject */
         $this->assertInstanceOf(ISubject::class, $subject);
-        $this->assertEquals('Dave', $subject->getPrimaryPrincipal()->getId());
+        $this->assertSame('Dave', $subject->getPrimaryPrincipal()->getId());
         $this->assertEquals([$this->credential], $subject->getCredentials());
     }
 }

--- a/src/Opulence/Authentication/Tests/Credentials/Authenticators/RefreshTokenAuthenticatorTest.php
+++ b/src/Opulence/Authentication/Tests/Credentials/Authenticators/RefreshTokenAuthenticatorTest.php
@@ -85,7 +85,7 @@ class RefreshTokenAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $subject = null;
         $error = null;
         $this->assertFalse($this->authenticator->authenticate($credential, $subject, $error));
-        $this->assertEquals(AuthenticatorErrorTypes::CREDENTIAL_MISSING, $error);
+        $this->assertSame(AuthenticatorErrorTypes::CREDENTIAL_MISSING, $error);
     }
 
     /**
@@ -100,7 +100,7 @@ class RefreshTokenAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $subject = null;
         $error = null;
         $this->assertFalse($this->authenticator->authenticate($this->credential, $subject, $error));
-        $this->assertEquals(AuthenticatorErrorTypes::CREDENTIAL_INCORRECT, $error);
+        $this->assertSame(AuthenticatorErrorTypes::CREDENTIAL_INCORRECT, $error);
     }
 
     /**
@@ -118,7 +118,7 @@ class RefreshTokenAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $subject = null;
         $error = null;
         $this->assertFalse($this->authenticator->authenticate($this->credential, $subject, $error));
-        $this->assertEquals(AuthenticatorErrorTypes::CREDENTIAL_INCORRECT, $error);
+        $this->assertSame(AuthenticatorErrorTypes::CREDENTIAL_INCORRECT, $error);
     }
 
     /**
@@ -137,7 +137,7 @@ class RefreshTokenAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->authenticator->authenticate($this->credential, $subject));
         /** @var ISubject $subject */
         $this->assertInstanceOf(ISubject::class, $subject);
-        $this->assertEquals('Dave', $subject->getPrimaryPrincipal()->getId());
+        $this->assertSame('Dave', $subject->getPrimaryPrincipal()->getId());
         $this->assertEquals([$this->credential], $subject->getCredentials());
     }
 }

--- a/src/Opulence/Authentication/Tests/Credentials/Authenticators/UsernamePasswordAuthenticatorTest.php
+++ b/src/Opulence/Authentication/Tests/Credentials/Authenticators/UsernamePasswordAuthenticatorTest.php
@@ -74,7 +74,7 @@ class UsernamePasswordAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->authenticator->authenticate($this->credential, $subject));
         /** @var ISubject $subject */
         $this->assertInstanceOf(ISubject::class, $subject);
-        $this->assertEquals('userId', $subject->getPrimaryPrincipal()->getId());
+        $this->assertSame('userId', $subject->getPrimaryPrincipal()->getId());
         $this->assertEquals(['role'], $subject->getPrimaryPrincipal()->getRoles());
         $this->assertEquals([$this->credential], $subject->getCredentials());
     }
@@ -103,7 +103,7 @@ class UsernamePasswordAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $subject = null;
         $error = null;
         $this->assertFalse($this->authenticator->authenticate($this->credential, $subject, $error));
-        $this->assertEquals(AuthenticatorErrorTypes::CREDENTIAL_INCORRECT, $error);
+        $this->assertSame(AuthenticatorErrorTypes::CREDENTIAL_INCORRECT, $error);
     }
 
     /**
@@ -126,7 +126,7 @@ class UsernamePasswordAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $subject = null;
         $error = null;
         $this->assertFalse($this->authenticator->authenticate($this->credential, $subject, $error));
-        $this->assertEquals(AuthenticatorErrorTypes::NO_SUBJECT, $error);
+        $this->assertSame(AuthenticatorErrorTypes::NO_SUBJECT, $error);
     }
 
     /**
@@ -145,7 +145,7 @@ class UsernamePasswordAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $subject = null;
         $error = null;
         $this->assertFalse($this->authenticator->authenticate($this->credential, $subject, $error));
-        $this->assertEquals(AuthenticatorErrorTypes::CREDENTIAL_MISSING, $error);
+        $this->assertSame(AuthenticatorErrorTypes::CREDENTIAL_MISSING, $error);
     }
 
     /**
@@ -164,6 +164,6 @@ class UsernamePasswordAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $subject = null;
         $error = null;
         $this->assertFalse($this->authenticator->authenticate($this->credential, $subject, $error));
-        $this->assertEquals(AuthenticatorErrorTypes::CREDENTIAL_MISSING, $error);
+        $this->assertSame(AuthenticatorErrorTypes::CREDENTIAL_MISSING, $error);
     }
 }

--- a/src/Opulence/Authentication/Tests/Credentials/CredentialTest.php
+++ b/src/Opulence/Authentication/Tests/Credentials/CredentialTest.php
@@ -33,7 +33,7 @@ class CredentialTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingType()
     {
-        $this->assertEquals('foo', $this->credential->getType());
+        $this->assertSame('foo', $this->credential->getType());
     }
 
     /**
@@ -41,7 +41,7 @@ class CredentialTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingValue()
     {
-        $this->assertEquals('baz', $this->credential->getValue('bar'));
+        $this->assertSame('baz', $this->credential->getValue('bar'));
     }
 
     /**

--- a/src/Opulence/Authentication/Tests/Credentials/Factories/AccessTokenCredentialFactoryTest.php
+++ b/src/Opulence/Authentication/Tests/Credentials/Factories/AccessTokenCredentialFactoryTest.php
@@ -90,13 +90,13 @@ class AccessTokenCredentialFactoryTest extends \PHPUnit\Framework\TestCase
         /** @var SignedJwt $signedJwt */
         $signedJwt = SignedJwt::createFromString($tokenString);
         $payload = $signedJwt->getPayload();
-        $this->assertEquals('foo', $payload->getIssuer());
+        $this->assertSame('foo', $payload->getIssuer());
         $this->assertEquals(['bar', 'baz'], $payload->getAudience());
-        $this->assertEquals('principalId', $payload->getSubject());
-        $this->assertEquals((new DateTimeImmutable)->format('Y'), $payload->getValidFrom()->format('Y'));
-        $this->assertEquals((new DateTimeImmutable('+1 year'))->format('Y'), $payload->getValidTo()->format('Y'));
-        $this->assertEquals((new DateTimeImmutable)->format('Y'), $payload->getIssuedAt()->format('Y'));
+        $this->assertSame('principalId', $payload->getSubject());
+        $this->assertSame((new DateTimeImmutable)->format('Y'), $payload->getValidFrom()->format('Y'));
+        $this->assertSame((new DateTimeImmutable('+1 year'))->format('Y'), $payload->getValidTo()->format('Y'));
+        $this->assertSame((new DateTimeImmutable)->format('Y'), $payload->getIssuedAt()->format('Y'));
         $this->assertEquals(['role1', 'role2'], $payload->get('roles'));
-        $this->assertEquals('Dave', $payload->get('user')['username']);
+        $this->assertSame('Dave', $payload->get('user')['username']);
     }
 }

--- a/src/Opulence/Authentication/Tests/Credentials/Factories/RefreshTokenCredentialFactoryTest.php
+++ b/src/Opulence/Authentication/Tests/Credentials/Factories/RefreshTokenCredentialFactoryTest.php
@@ -66,11 +66,11 @@ class RefreshTokenCredentialFactoryTest extends \PHPUnit\Framework\TestCase
         /** @var SignedJwt $signedJwt */
         $signedJwt = SignedJwt::createFromString($tokenString);
         $payload = $signedJwt->getPayload();
-        $this->assertEquals('foo', $payload->getIssuer());
-        $this->assertEquals('bar', $payload->getAudience());
-        $this->assertEquals('principalId', $payload->getSubject());
-        $this->assertEquals((new DateTimeImmutable)->format('Y'), $payload->getValidFrom()->format('Y'));
-        $this->assertEquals((new DateTimeImmutable('+1 year'))->format('Y'), $payload->getValidTo()->format('Y'));
-        $this->assertEquals((new DateTimeImmutable)->format('Y'), $payload->getIssuedAt()->format('Y'));
+        $this->assertSame('foo', $payload->getIssuer());
+        $this->assertSame('bar', $payload->getAudience());
+        $this->assertSame('principalId', $payload->getSubject());
+        $this->assertSame((new DateTimeImmutable)->format('Y'), $payload->getValidFrom()->format('Y'));
+        $this->assertSame((new DateTimeImmutable('+1 year'))->format('Y'), $payload->getValidTo()->format('Y'));
+        $this->assertSame((new DateTimeImmutable)->format('Y'), $payload->getIssuedAt()->format('Y'));
     }
 }

--- a/src/Opulence/Authentication/Tests/PrincipalTest.php
+++ b/src/Opulence/Authentication/Tests/PrincipalTest.php
@@ -42,7 +42,7 @@ class PrincipalTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingId()
     {
-        $this->assertEquals('bar', $this->principal->getId());
+        $this->assertSame('bar', $this->principal->getId());
     }
 
     /**
@@ -58,6 +58,6 @@ class PrincipalTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingType()
     {
-        $this->assertEquals('foo', $this->principal->getType());
+        $this->assertSame('foo', $this->principal->getType());
     }
 }

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/JwtHeaderTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/JwtHeaderTest.php
@@ -36,7 +36,7 @@ class JwtHeaderTest extends \PHPUnit\Framework\TestCase
     public function testDefaultAlgorithmIsSha256()
     {
         $header = new JwtHeader();
-        $this->assertEquals('HS256', $header->getAlgorithm());
+        $this->assertSame('HS256', $header->getAlgorithm());
     }
 
     /**
@@ -44,7 +44,7 @@ class JwtHeaderTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingAlgorithm()
     {
-        $this->assertEquals('HS512', $this->header->getAlgorithm());
+        $this->assertSame('HS512', $this->header->getAlgorithm());
     }
 
     /**
@@ -68,7 +68,7 @@ class JwtHeaderTest extends \PHPUnit\Framework\TestCase
     public function testGettingContentType()
     {
         $this->header->add('cty', 'JWT');
-        $this->assertEquals('JWT', $this->header->getContentType());
+        $this->assertSame('JWT', $this->header->getContentType());
     }
 
     /**
@@ -80,13 +80,13 @@ class JwtHeaderTest extends \PHPUnit\Framework\TestCase
             'typ' => 'JWT',
             'alg' => 'HS512'
         ];
-        $this->assertEquals(
+        $this->assertSame(
             rtrim(strtr(base64_encode(json_encode($headers)), '+/', '-_'), '='),
             $this->header->encode()
         );
         $this->header->add('foo', 'bar');
         $headers['foo'] = 'bar';
-        $this->assertEquals(
+        $this->assertSame(
             rtrim(strtr(base64_encode(json_encode($headers)), '+/', '-_'), '='),
             $this->header->encode()
         );
@@ -97,7 +97,7 @@ class JwtHeaderTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingTokenType()
     {
-        $this->assertEquals('JWT', $this->header->getTokenType());
+        $this->assertSame('JWT', $this->header->getTokenType());
     }
 
     /**
@@ -107,9 +107,9 @@ class JwtHeaderTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertNull($this->header->get('foo'));
         $this->header->add('foo', 'bar');
-        $this->assertEquals('bar', $this->header->get('foo'));
+        $this->assertSame('bar', $this->header->get('foo'));
         $this->header->add('foo', 'baz');
-        $this->assertEquals('baz', $this->header->get('foo'));
+        $this->assertSame('baz', $this->header->get('foo'));
     }
 
     /**
@@ -127,6 +127,6 @@ class JwtHeaderTest extends \PHPUnit\Framework\TestCase
     public function testSettingNoneAlgorithm()
     {
         $this->header->add('alg', 'none');
-        $this->assertEquals('none', $this->header->getAlgorithm());
+        $this->assertSame('none', $this->header->getAlgorithm());
     }
 }

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/JwtPayloadTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/JwtPayloadTest.php
@@ -87,7 +87,7 @@ class JwtPayloadTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertNull($this->payload->getAudience());
         $this->payload->setAudience('foo');
-        $this->assertEquals('foo', $this->payload->getAudience());
+        $this->assertSame('foo', $this->payload->getAudience());
     }
 
     /**
@@ -105,14 +105,14 @@ class JwtPayloadTest extends \PHPUnit\Framework\TestCase
             'iat' => null,
             'jti' => $this->payload->getId()
         ];
-        $this->assertEquals(
+        $this->assertSame(
             rtrim(strtr(base64_encode(json_encode($claims)), '+/', '-_'), '='),
             $this->payload->encode()
         );
         $this->payload->add('bar', 'baz');
         $claims['jti'] = $this->payload->getId();
         $claims['bar'] = 'baz';
-        $this->assertEquals(
+        $this->assertSame(
             rtrim(strtr(base64_encode(json_encode($claims)), '+/', '-_'), '='),
             $this->payload->encode()
         );
@@ -145,7 +145,7 @@ class JwtPayloadTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertNull($this->payload->getIssuer());
         $this->payload->setIssuer('foo');
-        $this->assertEquals('foo', $this->payload->getIssuer());
+        $this->assertSame('foo', $this->payload->getIssuer());
     }
 
     /**
@@ -155,7 +155,7 @@ class JwtPayloadTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertNull($this->payload->getSubject());
         $this->payload->setSubject('foo');
-        $this->assertEquals('foo', $this->payload->getSubject());
+        $this->assertSame('foo', $this->payload->getSubject());
     }
 
     /**
@@ -187,9 +187,9 @@ class JwtPayloadTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertNull($this->payload->get('foo'));
         $this->payload->add('foo', 'bar');
-        $this->assertEquals('bar', $this->payload->get('foo'));
+        $this->assertSame('bar', $this->payload->get('foo'));
         $this->payload->add('foo', 'baz');
-        $this->assertEquals('baz', $this->payload->get('foo'));
+        $this->assertSame('baz', $this->payload->get('foo'));
     }
 
     /**
@@ -217,8 +217,8 @@ class JwtPayloadTest extends \PHPUnit\Framework\TestCase
         $jti2 = $this->payload->getId();
         $this->payload->add('baz', 'blah');
         $jti3 = $this->payload->getId();
-        $this->assertEquals('theJti', $this->payload->getId());
-        $this->assertEquals('theJti', $this->payload->get('jti'));
+        $this->assertSame('theJti', $this->payload->getId());
+        $this->assertSame('theJti', $this->payload->get('jti'));
         $this->assertEquals($jti1, $jti2);
         $this->assertEquals($jti2, $jti3);
     }
@@ -238,8 +238,8 @@ class JwtPayloadTest extends \PHPUnit\Framework\TestCase
     public function testSettingId()
     {
         $this->payload->setId('foo');
-        $this->assertEquals('foo', $this->payload->get('jti'));
-        $this->assertEquals('foo', $this->payload->getId());
+        $this->assertSame('foo', $this->payload->get('jti'));
+        $this->assertSame('foo', $this->payload->getId());
     }
 
     /**

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/SignedJwtTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/SignedJwtTest.php
@@ -46,7 +46,7 @@ class SignedJwtTest extends \PHPUnit\Framework\TestCase
         $signedJwt = SignedJwt::createFromUnsignedJwt(new UnsignedJwt($this->header, $this->payload), 'foo');
         $this->assertSame($this->header, $signedJwt->getHeader());
         $this->assertSame($this->payload, $signedJwt->getPayload());
-        $this->assertEquals('foo', $signedJwt->getSignature());
+        $this->assertSame('foo', $signedJwt->getSignature());
     }
 
     /**
@@ -57,8 +57,8 @@ class SignedJwtTest extends \PHPUnit\Framework\TestCase
         $header = new JwtHeader('none');
         $unsignedJwt = new UnsignedJwt($header, new JwtPayload());
         $signedJwt = SignedJwt::createFromString($unsignedJwt->getUnsignedValue());
-        $this->assertEquals('none', $signedJwt->getHeader()->getAlgorithm());
-        $this->assertEquals('', $signedJwt->getSignature());
+        $this->assertSame('none', $signedJwt->getHeader()->getAlgorithm());
+        $this->assertSame('', $signedJwt->getSignature());
     }
 
     /**
@@ -128,7 +128,7 @@ class SignedJwtTest extends \PHPUnit\Framework\TestCase
     public function testGettingSignature()
     {
         $jwt = new SignedJwt($this->header, $this->payload, 'signature');
-        $this->assertEquals('signature', $jwt->getSignature());
+        $this->assertSame('signature', $jwt->getSignature());
     }
 
     /**
@@ -148,7 +148,7 @@ class SignedJwtTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($payloadA, $payloadB);
 
         if ($checkSignature) {
-            $this->assertEquals($a->getSignature(), $b->getSignature());
+            $this->assertSame($a->getSignature(), $b->getSignature());
         }
     }
 }

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/UnsignedJwtTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/UnsignedJwtTest.php
@@ -57,7 +57,7 @@ class UnsignedJwtTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingUnsignedValue()
     {
-        $this->assertEquals(
+        $this->assertSame(
             "{$this->jwt->getHeader()->encode()}.{$this->jwt->getPayload()->encode()}",
             $this->jwt->getUnsignedValue()
         );
@@ -69,7 +69,7 @@ class UnsignedJwtTest extends \PHPUnit\Framework\TestCase
     public function testGettingUnsignedValueWithNoneAlgorithm()
     {
         $this->header->add('alg', 'none');
-        $this->assertEquals(
+        $this->assertSame(
             "{$this->jwt->getHeader()->encode()}.{$this->jwt->getPayload()->encode()}.",
             $this->jwt->getUnsignedValue()
         );

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/AudienceVerifierTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/AudienceVerifierTest.php
@@ -49,7 +49,7 @@ class AudienceVerifierTest extends \PHPUnit\Framework\TestCase
             ->method('getAudience')
             ->willReturn('bar');
         $this->assertFalse($verifier->verify($this->jwt, $error));
-        $this->assertEquals(JwtErrorTypes::AUDIENCE_INVALID, $error);
+        $this->assertSame(JwtErrorTypes::AUDIENCE_INVALID, $error);
     }
 
     /**
@@ -62,7 +62,7 @@ class AudienceVerifierTest extends \PHPUnit\Framework\TestCase
             ->method('getAudience')
             ->willReturn('bar');
         $this->assertFalse($verifier->verify($this->jwt, $error));
-        $this->assertEquals(JwtErrorTypes::AUDIENCE_INVALID, $error);
+        $this->assertSame(JwtErrorTypes::AUDIENCE_INVALID, $error);
     }
 
     /**

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/ExpirationVerifierTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/ExpirationVerifierTest.php
@@ -53,7 +53,7 @@ class ExpirationVerifierTest extends \PHPUnit\Framework\TestCase
             ->method('getValidTo')
             ->willReturn($date);
         $this->assertFalse($this->verifier->verify($this->jwt, $error));
-        $this->assertEquals(JwtErrorTypes::EXPIRED, $error);
+        $this->assertSame(JwtErrorTypes::EXPIRED, $error);
     }
 
     /**

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/IssuerVerifierTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/IssuerVerifierTest.php
@@ -51,7 +51,7 @@ class IssuerVerifierTest extends \PHPUnit\Framework\TestCase
             ->method('getIssuer')
             ->willReturn('bar');
         $this->assertFalse($this->verifier->verify($this->jwt, $error));
-        $this->assertEquals(JwtErrorTypes::ISSUER_INVALID, $error);
+        $this->assertSame(JwtErrorTypes::ISSUER_INVALID, $error);
     }
 
     /**

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/NotBeforeVerifierTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/NotBeforeVerifierTest.php
@@ -53,7 +53,7 @@ class NotBeforeVerifierTest extends \PHPUnit\Framework\TestCase
             ->method('getValidFrom')
             ->willReturn($date);
         $this->assertFalse($this->verifier->verify($this->jwt, $error));
-        $this->assertEquals(JwtErrorTypes::NOT_ACTIVATED, $error);
+        $this->assertSame(JwtErrorTypes::NOT_ACTIVATED, $error);
     }
 
     /**

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/SignatureVerifierTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/SignatureVerifierTest.php
@@ -50,7 +50,7 @@ class SignatureVerifierTest extends \PHPUnit\Framework\TestCase
             ->method('getSignature')
             ->willReturn('');
         $this->assertFalse($this->verifier->verify($this->jwt, $error));
-        $this->assertEquals(JwtErrorTypes::SIGNATURE_INCORRECT, $error);
+        $this->assertSame(JwtErrorTypes::SIGNATURE_INCORRECT, $error);
     }
 
     /**
@@ -65,7 +65,7 @@ class SignatureVerifierTest extends \PHPUnit\Framework\TestCase
             ->method('verify')
             ->willReturn(false);
         $this->assertFalse($this->verifier->verify($this->jwt, $error));
-        $this->assertEquals(JwtErrorTypes::SIGNATURE_INCORRECT, $error);
+        $this->assertSame(JwtErrorTypes::SIGNATURE_INCORRECT, $error);
     }
 
     /**
@@ -90,7 +90,7 @@ class SignatureVerifierTest extends \PHPUnit\Framework\TestCase
             ->method('getAlgorithm')
             ->willReturn(Algorithms::SHA384);
         $this->assertFalse($this->verifier->verify($this->jwt, $error));
-        $this->assertEquals(JwtErrorTypes::SIGNATURE_ALGORITHM_MISMATCH, $error);
+        $this->assertSame(JwtErrorTypes::SIGNATURE_ALGORITHM_MISMATCH, $error);
     }
 
     /**

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/SubjectVerifierTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/SubjectVerifierTest.php
@@ -51,7 +51,7 @@ class SubjectVerifierTest extends \PHPUnit\Framework\TestCase
             ->method('getSubject')
             ->willReturn('bar');
         $this->assertFalse($this->verifier->verify($this->jwt, $error));
-        $this->assertEquals(JwtErrorTypes::SUBJECT_INVALID, $error);
+        $this->assertSame(JwtErrorTypes::SUBJECT_INVALID, $error);
     }
 
     /**

--- a/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/VerificationContextTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/JsonWebTokens/Verification/VerificationContextTest.php
@@ -58,7 +58,7 @@ class VerificationContextTest extends \PHPUnit\Framework\TestCase
     public function testSettingIssuer()
     {
         $this->context->setIssuer('foo');
-        $this->assertEquals('foo', $this->context->getIssuer());
+        $this->assertSame('foo', $this->context->getIssuer());
     }
 
     /**
@@ -78,6 +78,6 @@ class VerificationContextTest extends \PHPUnit\Framework\TestCase
     public function testSettingSubject()
     {
         $this->context->setSubject('foo');
-        $this->assertEquals('foo', $this->context->getSubject());
+        $this->assertSame('foo', $this->context->getSubject());
     }
 }

--- a/src/Opulence/Authentication/Tests/Tokens/Signatures/HmacSignerTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/Signatures/HmacSignerTest.php
@@ -46,7 +46,7 @@ class HmacSignerTest extends \PHPUnit\Framework\TestCase
     public function testGettingAlgorithm()
     {
         $signer = new HmacSigner(Algorithms::RSA_SHA512, 'public', 'private');
-        $this->assertEquals(Algorithms::RSA_SHA512, $signer->getAlgorithm());
+        $this->assertSame(Algorithms::RSA_SHA512, $signer->getAlgorithm());
     }
 
     /**
@@ -62,7 +62,7 @@ class HmacSignerTest extends \PHPUnit\Framework\TestCase
 
         foreach ($algorithms as $jwtAlgorithm => $hashAlgorithm) {
             $signer = new HmacSigner($jwtAlgorithm, 'public');
-            $this->assertEquals(
+            $this->assertSame(
                 hash_hmac($hashAlgorithm, $this->unsignedToken->getUnsignedValue(), 'public', true),
                 $signer->sign($this->unsignedToken->getUnsignedValue())
             );

--- a/src/Opulence/Authentication/Tests/Tokens/Signatures/RsaSsaPkcsSignerTest.php
+++ b/src/Opulence/Authentication/Tests/Tokens/Signatures/RsaSsaPkcsSignerTest.php
@@ -46,7 +46,7 @@ class RsaSsaPkcsSignerTest extends \PHPUnit\Framework\TestCase
     public function testGettingAlgorithm()
     {
         $signer = new RsaSsaPkcsSigner(Algorithms::RSA_SHA512, 'public', 'private');
-        $this->assertEquals(Algorithms::RSA_SHA512, $signer->getAlgorithm());
+        $this->assertSame(Algorithms::RSA_SHA512, $signer->getAlgorithm());
     }
 
     /**

--- a/src/Opulence/Authorization/Tests/AuthorityTest.php
+++ b/src/Opulence/Authorization/Tests/AuthorityTest.php
@@ -73,9 +73,9 @@ class AuthorityTest extends \PHPUnit\Framework\TestCase
     public function testOverrideUsed()
     {
         $this->permissionRegistry->registerOverrideCallback(function ($userId, string $permission, $argument) {
-            $this->assertEquals(23, $userId);
-            $this->assertEquals('foo', $permission);
-            $this->assertEquals('bar', $argument);
+            $this->assertSame(23, $userId);
+            $this->assertSame('foo', $permission);
+            $this->assertSame('bar', $argument);
 
             return true;
         });

--- a/src/Opulence/Authorization/Tests/Roles/RoleMembershipTest.php
+++ b/src/Opulence/Authorization/Tests/Roles/RoleMembershipTest.php
@@ -37,7 +37,7 @@ class RoleMembershipTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingId()
     {
-        $this->assertEquals(1, $this->membership->getId());
+        $this->assertSame(1, $this->membership->getId());
     }
 
     /**
@@ -53,7 +53,7 @@ class RoleMembershipTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingUserId()
     {
-        $this->assertEquals(2, $this->membership->getSubjectId());
+        $this->assertSame(2, $this->membership->getSubjectId());
     }
 
     /**
@@ -62,6 +62,6 @@ class RoleMembershipTest extends \PHPUnit\Framework\TestCase
     public function testSettingId()
     {
         $this->membership->setId(23);
-        $this->assertEquals(23, $this->membership->getId());
+        $this->assertSame(23, $this->membership->getId());
     }
 }

--- a/src/Opulence/Authorization/Tests/Roles/RoleTest.php
+++ b/src/Opulence/Authorization/Tests/Roles/RoleTest.php
@@ -33,7 +33,7 @@ class RoleTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingId()
     {
-        $this->assertEquals(1, $this->role->getId());
+        $this->assertSame(1, $this->role->getId());
     }
 
     /**
@@ -41,7 +41,7 @@ class RoleTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingName()
     {
-        $this->assertEquals('foo', $this->role->getName());
+        $this->assertSame('foo', $this->role->getName());
     }
 
     /**
@@ -50,6 +50,6 @@ class RoleTest extends \PHPUnit\Framework\TestCase
     public function testSettingId()
     {
         $this->role->setId(23);
-        $this->assertEquals(23, $this->role->getId());
+        $this->assertSame(23, $this->role->getId());
     }
 }

--- a/src/Opulence/Cache/Tests/ArrayBridgeTest.php
+++ b/src/Opulence/Cache/Tests/ArrayBridgeTest.php
@@ -49,9 +49,9 @@ class ArrayBridgeTest extends \PHPUnit\Framework\TestCase
     {
         $this->bridge->set('foo', 11, 60);
         // Test using default value
-        $this->assertEquals(10, $this->bridge->decrement('foo'));
+        $this->assertSame(10, $this->bridge->decrement('foo'));
         // Test using a custom value
-        $this->assertEquals(5, $this->bridge->decrement('foo', 5));
+        $this->assertSame(5, $this->bridge->decrement('foo', 5));
     }
 
     /**
@@ -90,7 +90,7 @@ class ArrayBridgeTest extends \PHPUnit\Framework\TestCase
     public function testGettingSetValue()
     {
         $this->bridge->set('foo', 'bar', 60);
-        $this->assertEquals('bar', $this->bridge->get('foo'));
+        $this->assertSame('bar', $this->bridge->get('foo'));
     }
 
     /**
@@ -100,9 +100,9 @@ class ArrayBridgeTest extends \PHPUnit\Framework\TestCase
     {
         $this->bridge->set('foo', 1, 60);
         // Test using default value
-        $this->assertEquals(2, $this->bridge->increment('foo'));
+        $this->assertSame(2, $this->bridge->increment('foo'));
         // Test using a custom value
-        $this->assertEquals(7, $this->bridge->increment('foo', 5));
+        $this->assertSame(7, $this->bridge->increment('foo', 5));
     }
 
     /**

--- a/src/Opulence/Cache/Tests/FileBridgeTest.php
+++ b/src/Opulence/Cache/Tests/FileBridgeTest.php
@@ -73,9 +73,9 @@ class FileBridgeTest extends \PHPUnit\Framework\TestCase
     {
         $this->bridge->set('foo', 11, 60);
         // Test using default value
-        $this->assertEquals(10, $this->bridge->decrement('foo'));
+        $this->assertSame(10, $this->bridge->decrement('foo'));
         // Test using a custom value
-        $this->assertEquals(5, $this->bridge->decrement('foo', 5));
+        $this->assertSame(5, $this->bridge->decrement('foo', 5));
     }
 
     /**
@@ -124,7 +124,7 @@ class FileBridgeTest extends \PHPUnit\Framework\TestCase
     public function testGettingSetValue()
     {
         $this->bridge->set('foo', 'bar', 60);
-        $this->assertEquals('bar', $this->bridge->get('foo'));
+        $this->assertSame('bar', $this->bridge->get('foo'));
     }
 
     /**
@@ -134,9 +134,9 @@ class FileBridgeTest extends \PHPUnit\Framework\TestCase
     {
         $this->bridge->set('foo', 1, 60);
         // Test using default value
-        $this->assertEquals(2, $this->bridge->increment('foo'));
+        $this->assertSame(2, $this->bridge->increment('foo'));
         // Test using a custom value
-        $this->assertEquals(7, $this->bridge->increment('foo', 5));
+        $this->assertSame(7, $this->bridge->increment('foo', 5));
     }
 
     /**
@@ -147,6 +147,6 @@ class FileBridgeTest extends \PHPUnit\Framework\TestCase
         $bridge = new FileBridge(__DIR__ . '/tmp/');
         $bridge->set('foo', 'bar', 60);
         $this->assertFileExists(__DIR__ . '/tmp/' . md5('foo'));
-        $this->assertEquals('bar', $bridge->get('foo'));
+        $this->assertSame('bar', $bridge->get('foo'));
     }
 }

--- a/src/Opulence/Cache/Tests/MemcachedBridgeTest.php
+++ b/src/Opulence/Cache/Tests/MemcachedBridgeTest.php
@@ -75,9 +75,9 @@ class MemcachedBridgeTest extends \PHPUnit\Framework\TestCase
             ->with('dave:foo', 5)
             ->willReturn(5);
         // Test using default value
-        $this->assertEquals(10, $this->bridge->decrement('foo'));
+        $this->assertSame(10, $this->bridge->decrement('foo'));
         // Test using a custom value
-        $this->assertEquals(5, $this->bridge->decrement('foo', 5));
+        $this->assertSame(5, $this->bridge->decrement('foo', 5));
     }
 
     /**
@@ -134,7 +134,7 @@ class MemcachedBridgeTest extends \PHPUnit\Framework\TestCase
         $this->client->expects($this->once())
             ->method('getResultCode')
             ->willReturn(0);
-        $this->assertEquals('bar', $this->bridge->get('foo'));
+        $this->assertSame('bar', $this->bridge->get('foo'));
     }
 
     /**
@@ -151,9 +151,9 @@ class MemcachedBridgeTest extends \PHPUnit\Framework\TestCase
             ->with('dave:foo', 5)
             ->willReturn(7);
         // Test using default value
-        $this->assertEquals(2, $this->bridge->increment('foo'));
+        $this->assertSame(2, $this->bridge->increment('foo'));
         // Test using a custom value
-        $this->assertEquals(7, $this->bridge->increment('foo', 5));
+        $this->assertSame(7, $this->bridge->increment('foo', 5));
     }
 
     /**
@@ -217,6 +217,6 @@ class MemcachedBridgeTest extends \PHPUnit\Framework\TestCase
             ->with('foo')
             ->willReturn($client);
         $bridge = new MemcachedBridge($memcached, 'foo');
-        $this->assertEquals('baz', $bridge->get('bar'));
+        $this->assertSame('baz', $bridge->get('bar'));
     }
 }

--- a/src/Opulence/Cache/Tests/RedisBridgeTest.php
+++ b/src/Opulence/Cache/Tests/RedisBridgeTest.php
@@ -75,9 +75,9 @@ class RedisBridgeTest extends \PHPUnit\Framework\TestCase
             ->with('dave:foo', 5)
             ->willReturn(5);
         // Test using default value
-        $this->assertEquals(10, $this->bridge->decrement('foo'));
+        $this->assertSame(10, $this->bridge->decrement('foo'));
         // Test using a custom value
-        $this->assertEquals(5, $this->bridge->decrement('foo', 5));
+        $this->assertSame(5, $this->bridge->decrement('foo', 5));
     }
 
     /**
@@ -117,7 +117,7 @@ class RedisBridgeTest extends \PHPUnit\Framework\TestCase
         $this->client->expects($this->once())
             ->method('get')
             ->willReturn('bar');
-        $this->assertEquals('bar', $this->bridge->get('foo'));
+        $this->assertSame('bar', $this->bridge->get('foo'));
     }
 
     /**
@@ -134,9 +134,9 @@ class RedisBridgeTest extends \PHPUnit\Framework\TestCase
             ->with('dave:foo', 5)
             ->willReturn(7);
         // Test using default value
-        $this->assertEquals(2, $this->bridge->increment('foo'));
+        $this->assertSame(2, $this->bridge->increment('foo'));
         // Test using a custom value
-        $this->assertEquals(7, $this->bridge->increment('foo', 5));
+        $this->assertSame(7, $this->bridge->increment('foo', 5));
     }
 
     /**
@@ -196,6 +196,6 @@ class RedisBridgeTest extends \PHPUnit\Framework\TestCase
             ->with('foo')
             ->willReturn($client);
         $bridge = new RedisBridge($redis, 'foo');
-        $this->assertEquals('baz', $bridge->get('bar'));
+        $this->assertSame('baz', $bridge->get('bar'));
     }
 }

--- a/src/Opulence/Collections/Tests/ArrayListTest.php
+++ b/src/Opulence/Collections/Tests/ArrayListTest.php
@@ -35,7 +35,7 @@ class ArrayListTest extends \PHPUnit\Framework\TestCase
     public function testAdding() : void
     {
         $this->arrayList->add('foo');
-        $this->assertEquals('foo', $this->arrayList->get(0));
+        $this->assertSame('foo', $this->arrayList->get(0));
     }
 
     /**
@@ -92,9 +92,9 @@ class ArrayListTest extends \PHPUnit\Framework\TestCase
     public function testCount() : void
     {
         $this->arrayList->add('foo');
-        $this->assertEquals(1, $this->arrayList->count());
+        $this->assertSame(1, $this->arrayList->count());
         $this->arrayList->add('bar');
-        $this->assertEquals(2, $this->arrayList->count());
+        $this->assertSame(2, $this->arrayList->count());
     }
 
     /**
@@ -103,7 +103,7 @@ class ArrayListTest extends \PHPUnit\Framework\TestCase
     public function testGetting() : void
     {
         $this->arrayList->add('foo');
-        $this->assertEquals('foo', $this->arrayList->get(0));
+        $this->assertSame('foo', $this->arrayList->get(0));
     }
 
     /**
@@ -142,7 +142,7 @@ class ArrayListTest extends \PHPUnit\Framework\TestCase
     public function testGettingAsArray() : void
     {
         $this->arrayList->add('foo');
-        $this->assertEquals('foo', $this->arrayList[0]);
+        $this->assertSame('foo', $this->arrayList[0]);
     }
 
     /**
@@ -153,8 +153,8 @@ class ArrayListTest extends \PHPUnit\Framework\TestCase
         $this->arrayList->add('foo');
         $this->arrayList->add('bar');
         $this->arrayList->insert(1, 'baz');
-        $this->assertEquals('baz', $this->arrayList->get(1));
-        $this->assertEquals('bar', $this->arrayList->get(2));
+        $this->assertSame('baz', $this->arrayList->get(1));
+        $this->assertSame('bar', $this->arrayList->get(2));
         $this->assertEquals(['foo', 'baz', 'bar'], $this->arrayList->toArray());
     }
 
@@ -201,7 +201,7 @@ class ArrayListTest extends \PHPUnit\Framework\TestCase
     {
         $this->arrayList->add('foo');
         $this->arrayList->removeValue('foo');
-        $this->assertEquals(0, $this->arrayList->count());
+        $this->assertSame(0, $this->arrayList->count());
         $this->assertFalse($this->arrayList->containsValue('foo'));
         $this->assertEquals([], $this->arrayList->toArray());
     }
@@ -213,7 +213,7 @@ class ArrayListTest extends \PHPUnit\Framework\TestCase
     {
         $this->arrayList->add('foo');
         $this->arrayList->removeIndex(0);
-        $this->assertEquals(0, $this->arrayList->count());
+        $this->assertSame(0, $this->arrayList->count());
         $this->assertFalse($this->arrayList->containsValue('foo'));
         $this->assertEquals([], $this->arrayList->toArray());
     }
@@ -237,7 +237,7 @@ class ArrayListTest extends \PHPUnit\Framework\TestCase
         $this->arrayList->add('foo');
         $this->arrayList->add('bar');
         $this->arrayList[1] = 'baz';
-        $this->assertEquals('baz', $this->arrayList[1]);
+        $this->assertSame('baz', $this->arrayList[1]);
         $this->assertEquals(['foo', 'baz', 'bar'], $this->arrayList->toArray());
     }
 
@@ -276,7 +276,7 @@ class ArrayListTest extends \PHPUnit\Framework\TestCase
     {
         $this->arrayList->add('foo');
         unset($this->arrayList[0]);
-        $this->assertEquals(0, $this->arrayList->count());
+        $this->assertSame(0, $this->arrayList->count());
         $this->assertFalse($this->arrayList->containsValue('foo'));
         $this->assertEquals([], $this->arrayList->toArray());
     }

--- a/src/Opulence/Collections/Tests/HashSetTest.php
+++ b/src/Opulence/Collections/Tests/HashSetTest.php
@@ -106,13 +106,13 @@ class HashSetTest extends \PHPUnit\Framework\TestCase
     {
         $object1 = new MockObject();
         $object2 = new MockObject();
-        $this->assertEquals(0, $this->set->count());
+        $this->assertSame(0, $this->set->count());
         $this->set->add($object1);
-        $this->assertEquals(1, $this->set->count());
+        $this->assertSame(1, $this->set->count());
         $this->set->add($object1);
-        $this->assertEquals(1, $this->set->count());
+        $this->assertSame(1, $this->set->count());
         $this->set->add($object2);
-        $this->assertEquals(2, $this->set->count());
+        $this->assertSame(2, $this->set->count());
     }
 
     /**
@@ -154,7 +154,7 @@ class HashSetTest extends \PHPUnit\Framework\TestCase
 
         foreach ($this->set as $key => $value) {
             // Make sure the hash keys aren't returned by the iterator
-            $this->assertTrue(is_int($key));
+            $this->assertIsInt($key);
             $actualValues[] = $value;
         }
 

--- a/src/Opulence/Collections/Tests/HashTableTest.php
+++ b/src/Opulence/Collections/Tests/HashTableTest.php
@@ -38,8 +38,8 @@ class HashTableTest extends \PHPUnit\Framework\TestCase
     public function testAddingRangeMakesEachValueRetrievable() : void
     {
         $this->hashTable->addRange([new KeyValuePair('foo', 'bar'), new KeyValuePair('baz', 'blah')]);
-        $this->assertEquals('bar', $this->hashTable->get('foo'));
-        $this->assertEquals('blah', $this->hashTable->get('baz'));
+        $this->assertSame('bar', $this->hashTable->get('foo'));
+        $this->assertSame('blah', $this->hashTable->get('baz'));
     }
 
     /**
@@ -48,7 +48,7 @@ class HashTableTest extends \PHPUnit\Framework\TestCase
     public function testAddingValueMakesItRetrievable() : void
     {
         $this->hashTable->add('foo', 'bar');
-        $this->assertEquals('bar', $this->hashTable->get('foo'));
+        $this->assertSame('bar', $this->hashTable->get('foo'));
     }
 
     /**
@@ -105,9 +105,9 @@ class HashTableTest extends \PHPUnit\Framework\TestCase
     public function testCount() : void
     {
         $this->hashTable->add('foo', 'bar');
-        $this->assertEquals(1, $this->hashTable->count());
+        $this->assertSame(1, $this->hashTable->count());
         $this->hashTable->add('bar', 'foo');
-        $this->assertEquals(2, $this->hashTable->count());
+        $this->assertSame(2, $this->hashTable->count());
     }
 
     /**
@@ -116,7 +116,7 @@ class HashTableTest extends \PHPUnit\Framework\TestCase
     public function testGetting() : void
     {
         $this->hashTable->add('foo', 'bar');
-        $this->assertEquals('bar', $this->hashTable->get('foo'));
+        $this->assertSame('bar', $this->hashTable->get('foo'));
     }
 
     /**
@@ -134,7 +134,7 @@ class HashTableTest extends \PHPUnit\Framework\TestCase
     public function testGettingAsArray() : void
     {
         $this->hashTable->add('foo', 'bar');
-        $this->assertEquals('bar', $this->hashTable['foo']);
+        $this->assertSame('bar', $this->hashTable['foo']);
     }
 
     /**
@@ -174,7 +174,7 @@ class HashTableTest extends \PHPUnit\Framework\TestCase
 
         foreach ($this->hashTable as $key => $value) {
             // Make sure the hash keys aren't returned by the iterator
-            $this->assertTrue(is_int($key));
+            $this->assertIsInt($key);
             $actualValues[] = $value;
         }
 
@@ -205,8 +205,8 @@ class HashTableTest extends \PHPUnit\Framework\TestCase
     public function testPassingParametersInConstructor() : void
     {
         $hashTable = new HashTable([new KeyValuePair('foo', 'bar'), new KeyValuePair('baz', 'blah')]);
-        $this->assertEquals('bar', $hashTable->get('foo'));
-        $this->assertEquals('blah', $hashTable->get('baz'));
+        $this->assertSame('bar', $hashTable->get('foo'));
+        $this->assertSame('blah', $hashTable->get('baz'));
     }
 
     /**
@@ -225,7 +225,7 @@ class HashTableTest extends \PHPUnit\Framework\TestCase
     public function testSettingItem() : void
     {
         $this->hashTable['foo'] = 'bar';
-        $this->assertEquals('bar', $this->hashTable['foo']);
+        $this->assertSame('bar', $this->hashTable['foo']);
     }
 
     /**
@@ -252,7 +252,7 @@ class HashTableTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($value);
         $this->hashTable->add('foo', 'bar');
         $this->assertTrue($this->hashTable->tryGet('foo', $value));
-        $this->assertEquals('bar', $value);
+        $this->assertSame('bar', $value);
     }
 
     /**

--- a/src/Opulence/Collections/Tests/ImmutableArrayListTest.php
+++ b/src/Opulence/Collections/Tests/ImmutableArrayListTest.php
@@ -53,9 +53,9 @@ class ImmutableArrayListTest extends \PHPUnit\Framework\TestCase
     public function testCount() : void
     {
         $arrayList = new ImmutableArrayList(['foo']);
-        $this->assertEquals(1, $arrayList->count());
+        $this->assertSame(1, $arrayList->count());
         $arrayList = new ImmutableArrayList(['foo', 'bar']);
-        $this->assertEquals(2, $arrayList->count());
+        $this->assertSame(2, $arrayList->count());
     }
 
     /**
@@ -64,7 +64,7 @@ class ImmutableArrayListTest extends \PHPUnit\Framework\TestCase
     public function testGetting() : void
     {
         $arrayList = new ImmutableArrayList(['foo']);
-        $this->assertEquals('foo', $arrayList->get(0));
+        $this->assertSame('foo', $arrayList->get(0));
     }
 
     /**
@@ -73,7 +73,7 @@ class ImmutableArrayListTest extends \PHPUnit\Framework\TestCase
     public function testGettingAsArray() : void
     {
         $arrayList = new ImmutableArrayList(['foo']);
-        $this->assertEquals('foo', $arrayList[0]);
+        $this->assertSame('foo', $arrayList[0]);
     }
 
     /**

--- a/src/Opulence/Collections/Tests/ImmutableHashSetTest.php
+++ b/src/Opulence/Collections/Tests/ImmutableHashSetTest.php
@@ -84,13 +84,13 @@ class ImmutableHashSetTest extends \PHPUnit\Framework\TestCase
     {
         $object1 = new MockObject('foo');
         $object2 = new MockObject('bar');
-        $this->assertEquals(0, (new ImmutableHashSet([]))->count());
+        $this->assertSame(0, (new ImmutableHashSet([]))->count());
         $setWithOneValue = new ImmutableHashSet([$object1]);
-        $this->assertEquals(1, $setWithOneValue->count());
+        $this->assertSame(1, $setWithOneValue->count());
         $setWithOneUniqueValue = new ImmutableHashSet([$object1, $object1]);
-        $this->assertEquals(1, $setWithOneUniqueValue->count());
+        $this->assertSame(1, $setWithOneUniqueValue->count());
         $setWithTwoalues = new ImmutableHashSet([$object1, $object2]);
-        $this->assertEquals(2, $setWithTwoalues->count());
+        $this->assertSame(2, $setWithTwoalues->count());
     }
 
     /**
@@ -107,7 +107,7 @@ class ImmutableHashSetTest extends \PHPUnit\Framework\TestCase
 
         foreach ($set as $key => $value) {
             // Make sure the hash keys aren't returned by the iterator
-            $this->assertTrue(is_int($key));
+            $this->assertIsInt($key);
             $actualValues[] = $value;
         }
 

--- a/src/Opulence/Collections/Tests/ImmutableHashTableTest.php
+++ b/src/Opulence/Collections/Tests/ImmutableHashTableTest.php
@@ -57,7 +57,7 @@ class ImmutableHashTableTest extends \PHPUnit\Framework\TestCase
     public function testCount() : void
     {
         $hashTable = new ImmutableHashTable([new KeyValuePair('foo', 'bar'), new KeyValuePair('baz', 'blah')]);
-        $this->assertEquals(2, $hashTable->count());
+        $this->assertSame(2, $hashTable->count());
     }
 
     /**
@@ -66,7 +66,7 @@ class ImmutableHashTableTest extends \PHPUnit\Framework\TestCase
     public function testGetting() : void
     {
         $hashTable = new ImmutableHashTable([new KeyValuePair('foo', 'bar')]);
-        $this->assertEquals('bar', $hashTable->get('foo'));
+        $this->assertSame('bar', $hashTable->get('foo'));
     }
 
     /**
@@ -115,7 +115,7 @@ class ImmutableHashTableTest extends \PHPUnit\Framework\TestCase
 
         foreach ($hashTable as $key => $value) {
             // Make sure the hash keys aren't returned by the iterator
-            $this->assertTrue(is_int($key));
+            $this->assertIsInt($key);
             $actualValues[] = $value;
         }
 
@@ -164,7 +164,7 @@ class ImmutableHashTableTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($hashTable->tryGet('baz', $value));
         $this->assertNull($value);
         $this->assertTrue($hashTable->tryGet('foo', $value));
-        $this->assertEquals('bar', $value);
+        $this->assertSame('bar', $value);
     }
 
     /**

--- a/src/Opulence/Collections/Tests/KeyHasherTest.php
+++ b/src/Opulence/Collections/Tests/KeyHasherTest.php
@@ -36,7 +36,7 @@ class KeyHasherTest extends \PHPUnit\Framework\TestCase
     public function testArraysAreHashedToCorrectKey() : void
     {
         $array = ['foo'];
-        $this->assertEquals('__opulence:a:' . md5(serialize($array)), $this->keyHasher->getHashKey($array));
+        $this->assertSame('__opulence:a:' . md5(serialize($array)), $this->keyHasher->getHashKey($array));
     }
 
     /**
@@ -44,9 +44,9 @@ class KeyHasherTest extends \PHPUnit\Framework\TestCase
      */
     public function testScalarsAreHashedToCorrectKey() : void
     {
-        $this->assertEquals('__opulence:s:1', $this->keyHasher->getHashKey('1'));
-        $this->assertEquals('__opulence:i:1', $this->keyHasher->getHashKey(1));
-        $this->assertEquals('__opulence:f:1.1', $this->keyHasher->getHashKey(1.1));
+        $this->assertSame('__opulence:s:1', $this->keyHasher->getHashKey('1'));
+        $this->assertSame('__opulence:i:1', $this->keyHasher->getHashKey(1));
+        $this->assertSame('__opulence:f:1.1', $this->keyHasher->getHashKey(1.1));
     }
 
     /**
@@ -55,7 +55,7 @@ class KeyHasherTest extends \PHPUnit\Framework\TestCase
     public function testResourceIsHashedUsingItsStringValue() : void
     {
         $resource = fopen('php://temp', 'r+');
-        $this->assertEquals("__opulence:r:$resource", $this->keyHasher->getHashKey($resource));
+        $this->assertSame("__opulence:r:$resource", $this->keyHasher->getHashKey($resource));
     }
 
     /**
@@ -64,7 +64,7 @@ class KeyHasherTest extends \PHPUnit\Framework\TestCase
     public function testSerializableObjectIsHashedWithToStringMethod() : void
     {
         $object = new SerializableObject('foo');
-        $this->assertEquals('__opulence:so:foo', $this->keyHasher->getHashKey($object));
+        $this->assertSame('__opulence:so:foo', $this->keyHasher->getHashKey($object));
     }
 
     /**
@@ -73,6 +73,6 @@ class KeyHasherTest extends \PHPUnit\Framework\TestCase
     public function testUnserializableObjectIsHashedWithObjectHash() : void
     {
         $object = new UnserializableObject();
-        $this->assertEquals('__opulence:o:' . spl_object_hash($object), $this->keyHasher->getHashKey($object));
+        $this->assertSame('__opulence:o:' . spl_object_hash($object), $this->keyHasher->getHashKey($object));
     }
 }

--- a/src/Opulence/Collections/Tests/KeyValuePairTest.php
+++ b/src/Opulence/Collections/Tests/KeyValuePairTest.php
@@ -23,7 +23,7 @@ class KeyValuePairTest extends \PHPUnit\Framework\TestCase
     public function testGettingKey() : void
     {
         $kvp = new KeyValuePair('foo', 'bar');
-        $this->assertEquals('foo', $kvp->getKey());
+        $this->assertSame('foo', $kvp->getKey());
     }
 
     /**
@@ -32,6 +32,6 @@ class KeyValuePairTest extends \PHPUnit\Framework\TestCase
     public function testGettingValue() : void
     {
         $kvp = new KeyValuePair('foo', 'bar');
-        $this->assertEquals('bar', $kvp->getValue());
+        $this->assertSame('bar', $kvp->getValue());
     }
 }

--- a/src/Opulence/Collections/Tests/QueueTest.php
+++ b/src/Opulence/Collections/Tests/QueueTest.php
@@ -53,11 +53,11 @@ class QueueTest extends \PHPUnit\Framework\TestCase
      */
     public function testCounting() : void
     {
-        $this->assertEquals(0, $this->queue->count());
+        $this->assertSame(0, $this->queue->count());
         $this->queue->enqueue('foo');
-        $this->assertEquals(1, $this->queue->count());
+        $this->assertSame(1, $this->queue->count());
         $this->queue->enqueue('bar');
-        $this->assertEquals(2, $this->queue->count());
+        $this->assertSame(2, $this->queue->count());
     }
 
     /**
@@ -67,9 +67,9 @@ class QueueTest extends \PHPUnit\Framework\TestCase
     {
         $this->queue->enqueue('foo');
         $this->queue->enqueue('bar');
-        $this->assertEquals('foo', $this->queue->dequeue());
+        $this->assertSame('foo', $this->queue->dequeue());
         $this->assertEquals(['bar'], $this->queue->toArray());
-        $this->assertEquals('bar', $this->queue->dequeue());
+        $this->assertSame('bar', $this->queue->dequeue());
         $this->assertEquals([], $this->queue->toArray());
     }
 
@@ -88,8 +88,8 @@ class QueueTest extends \PHPUnit\Framework\TestCase
     {
         $this->queue->enqueue('foo');
         $this->queue->enqueue('bar');
-        $this->assertEquals('foo', $this->queue->dequeue());
-        $this->assertEquals('bar', $this->queue->dequeue());
+        $this->assertSame('foo', $this->queue->dequeue());
+        $this->assertSame('bar', $this->queue->dequeue());
     }
 
     /**
@@ -122,9 +122,9 @@ class QueueTest extends \PHPUnit\Framework\TestCase
     public function testPeekReturnsValueAtBeginning() : void
     {
         $this->queue->enqueue('foo');
-        $this->assertEquals('foo', $this->queue->peek());
+        $this->assertSame('foo', $this->queue->peek());
         $this->queue->enqueue('bar');
-        $this->assertEquals('foo', $this->queue->peek());
+        $this->assertSame('foo', $this->queue->peek());
     }
 
     /**

--- a/src/Opulence/Collections/Tests/StackTest.php
+++ b/src/Opulence/Collections/Tests/StackTest.php
@@ -53,11 +53,11 @@ class StackTest extends \PHPUnit\Framework\TestCase
      */
     public function testCounting() : void
     {
-        $this->assertEquals(0, $this->stack->count());
+        $this->assertSame(0, $this->stack->count());
         $this->stack->push('foo');
-        $this->assertEquals(1, $this->stack->count());
+        $this->assertSame(1, $this->stack->count());
         $this->stack->push('bar');
-        $this->assertEquals(2, $this->stack->count());
+        $this->assertSame(2, $this->stack->count());
     }
 
     /**
@@ -90,9 +90,9 @@ class StackTest extends \PHPUnit\Framework\TestCase
     public function testPeekReturnsTopValue() : void
     {
         $this->stack->push('foo');
-        $this->assertEquals('foo', $this->stack->peek());
+        $this->assertSame('foo', $this->stack->peek());
         $this->stack->push('bar');
-        $this->assertEquals('bar', $this->stack->peek());
+        $this->assertSame('bar', $this->stack->peek());
     }
 
     /**
@@ -102,9 +102,9 @@ class StackTest extends \PHPUnit\Framework\TestCase
     {
         $this->stack->push('foo');
         $this->stack->push('bar');
-        $this->assertEquals('bar', $this->stack->pop());
+        $this->assertSame('bar', $this->stack->pop());
         $this->assertEquals(['foo'], $this->stack->toArray());
-        $this->assertEquals('foo', $this->stack->pop());
+        $this->assertSame('foo', $this->stack->pop());
         $this->assertEquals([], $this->stack->toArray());
     }
 
@@ -123,8 +123,8 @@ class StackTest extends \PHPUnit\Framework\TestCase
     {
         $this->stack->push('foo');
         $this->stack->push('bar');
-        $this->assertEquals('bar', $this->stack->pop());
-        $this->assertEquals('foo', $this->stack->pop());
+        $this->assertSame('bar', $this->stack->pop());
+        $this->assertSame('foo', $this->stack->pop());
     }
 
     /**

--- a/src/Opulence/Console/Tests/Commands/CommandTest.php
+++ b/src/Opulence/Console/Tests/Commands/CommandTest.php
@@ -130,7 +130,7 @@ class CommandTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingDescription()
     {
-        $this->assertEquals('The foo command', $this->command->getDescription());
+        $this->assertSame('The foo command', $this->command->getDescription());
     }
 
     /**
@@ -138,7 +138,7 @@ class CommandTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingHelpText()
     {
-        $this->assertEquals("Bob Loblaw's Law Blog no habla Espanol", $this->command->getHelpText());
+        $this->assertSame("Bob Loblaw's Law Blog no habla Espanol", $this->command->getHelpText());
     }
 
     /**
@@ -146,7 +146,7 @@ class CommandTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingName()
     {
-        $this->assertEquals('foo', $this->command->getName());
+        $this->assertSame('foo', $this->command->getName());
     }
 
     /**
@@ -210,7 +210,7 @@ class CommandTest extends \PHPUnit\Framework\TestCase
     public function testSettingArgumentValue()
     {
         $this->command->setArgumentValue('foo', 'bar');
-        $this->assertEquals('bar', $this->command->getArgumentValue('foo'));
+        $this->assertSame('bar', $this->command->getArgumentValue('foo'));
     }
 
     /**
@@ -221,6 +221,6 @@ class CommandTest extends \PHPUnit\Framework\TestCase
         $option = new Option('foo', 'f', OptionTypes::OPTIONAL_VALUE, 'Foo command', 'bar');
         $this->command->addOption($option);
         $this->command->setOptionValue('foo', 'bar');
-        $this->assertEquals('bar', $this->command->getOptionValue('foo'));
+        $this->assertSame('bar', $this->command->getOptionValue('foo'));
     }
 }

--- a/src/Opulence/Console/Tests/Commands/CommandsCollectionTest.php
+++ b/src/Opulence/Console/Tests/Commands/CommandsCollectionTest.php
@@ -66,7 +66,7 @@ class CommandsCollectionTest extends \PHPUnit\Framework\TestCase
         $response = new Response(new Compiler(new Lexer(), new Parser()));
         ob_start();
         $this->collection->call('holiday', $response, ['Easter'], ['-y']);
-        $this->assertEquals('Happy Easter!', ob_get_clean());
+        $this->assertSame('Happy Easter!', ob_get_clean());
     }
 
     /**

--- a/src/Opulence/Console/Tests/Commands/Compilers/CompilerTest.php
+++ b/src/Opulence/Console/Tests/Commands/Compilers/CompilerTest.php
@@ -72,7 +72,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->request->addArgumentValue('baz');
         $compiledCommand = $this->compiler->compile($this->command, $this->request);
         $this->assertEquals(['bar', 'baz'], $compiledCommand->getArgumentValue('foo'));
-        $this->assertEquals('baz', $compiledCommand->getArgumentValue('bar'));
+        $this->assertSame('baz', $compiledCommand->getArgumentValue('bar'));
     }
 
     /**
@@ -122,7 +122,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->command->addOption($option);
         $this->request->addOptionValue('foo', 'bar');
         $compiledCommand = $this->compiler->compile($this->command, $this->request);
-        $this->assertEquals('bar', $compiledCommand->getOptionValue('foo'));
+        $this->assertSame('bar', $compiledCommand->getOptionValue('foo'));
     }
 
     /**
@@ -134,7 +134,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->command->addArgument($optionalArgument);
         $this->request->addArgumentValue('bar');
         $compiledCommand = $this->compiler->compile($this->command, $this->request);
-        $this->assertEquals('bar', $compiledCommand->getArgumentValue('foo'));
+        $this->assertSame('bar', $compiledCommand->getArgumentValue('foo'));
     }
 
     /**
@@ -145,7 +145,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $optionalArgument = new Argument('foo', ArgumentTypes::OPTIONAL, 'Foo command', 'baz');
         $this->command->addArgument($optionalArgument);
         $compiledCommand = $this->compiler->compile($this->command, $this->request);
-        $this->assertEquals('baz', $compiledCommand->getArgumentValue('foo'));
+        $this->assertSame('baz', $compiledCommand->getArgumentValue('foo'));
     }
 
     /**
@@ -158,8 +158,8 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->command->addArgument($optionalArgument1);
         $this->command->addArgument($optionalArgument2);
         $compiledCommand = $this->compiler->compile($this->command, $this->request);
-        $this->assertEquals('fooValue', $compiledCommand->getArgumentValue('foo'));
-        $this->assertEquals('barValue', $compiledCommand->getArgumentValue('bar'));
+        $this->assertSame('fooValue', $compiledCommand->getArgumentValue('foo'));
+        $this->assertSame('barValue', $compiledCommand->getArgumentValue('bar'));
     }
 
     /**
@@ -171,7 +171,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->command->addOption($option);
         $this->request->addOptionValue('foo', null);
         $compiledCommand = $this->compiler->compile($this->command, $this->request);
-        $this->assertEquals('bar', $compiledCommand->getOptionValue('foo'));
+        $this->assertSame('bar', $compiledCommand->getOptionValue('foo'));
     }
 
     /**
@@ -185,8 +185,8 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->command->addArgument($optionalArgument);
         $this->request->addArgumentValue('bar');
         $compiledCommand = $this->compiler->compile($this->command, $this->request);
-        $this->assertEquals('bar', $compiledCommand->getArgumentValue('foo'));
-        $this->assertEquals('baz', $compiledCommand->getArgumentValue('bar'));
+        $this->assertSame('bar', $compiledCommand->getArgumentValue('foo'));
+        $this->assertSame('baz', $compiledCommand->getArgumentValue('bar'));
     }
 
     /**
@@ -198,7 +198,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->command->addArgument($requiredArgument);
         $this->request->addArgumentValue('bar');
         $compiledCommand = $this->compiler->compile($this->command, $this->request);
-        $this->assertEquals('bar', $compiledCommand->getArgumentValue('foo'));
+        $this->assertSame('bar', $compiledCommand->getArgumentValue('foo'));
     }
 
     /**
@@ -235,7 +235,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->command->addOption($option);
         $this->request->addOptionValue('foo', 'bar');
         $compiledCommand = $this->compiler->compile($this->command, $this->request);
-        $this->assertEquals('bar', $compiledCommand->getOptionValue('foo'));
+        $this->assertSame('bar', $compiledCommand->getOptionValue('foo'));
     }
 
     /**
@@ -262,8 +262,8 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->command->addOption($optionalValueOption);
         $this->command->addOption($noValueOption);
         $compiledCommand = $this->compiler->compile($this->command, $this->request);
-        $this->assertEquals('foo value', $compiledCommand->getOptionValue('foo'));
-        $this->assertEquals('bar value', $compiledCommand->getOptionValue('bar'));
+        $this->assertSame('foo value', $compiledCommand->getOptionValue('foo'));
+        $this->assertSame('bar value', $compiledCommand->getOptionValue('bar'));
         $this->assertNull($compiledCommand->getOptionValue('baz'));
     }
 
@@ -289,6 +289,6 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->command->addOption($option);
         $this->request->addOptionValue('f', null);
         $compiledCommand = $this->compiler->compile($this->command, $this->request);
-        $this->assertEquals('bar', $compiledCommand->getOptionValue('foo'));
+        $this->assertSame('bar', $compiledCommand->getOptionValue('foo'));
     }
 }

--- a/src/Opulence/Console/Tests/KernelTest.php
+++ b/src/Opulence/Console/Tests/KernelTest.php
@@ -66,7 +66,7 @@ class KernelTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $status = $this->kernel->handle("unclosed quote '", $this->response);
         ob_end_clean();
-        $this->assertEquals(StatusCodes::FATAL, $status);
+        $this->assertSame(StatusCodes::FATAL, $status);
     }
 
     /**
@@ -78,25 +78,25 @@ class KernelTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $status = $this->kernel->handle('help holiday', $this->response);
         ob_get_clean();
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame(StatusCodes::OK, $status);
 
         // Try with command name with no argument
         ob_start();
         $status = $this->kernel->handle('help', $this->response);
         ob_get_clean();
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame(StatusCodes::OK, $status);
 
         // Try with short name
         ob_start();
         $status = $this->kernel->handle('holiday -h', $this->response);
         ob_get_clean();
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame(StatusCodes::OK, $status);
 
         // Try with long name
         ob_start();
         $status = $this->kernel->handle('holiday --help', $this->response);
         ob_get_clean();
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame(StatusCodes::OK, $status);
     }
 
     /**
@@ -107,7 +107,7 @@ class KernelTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $status = $this->kernel->handle('help fake', $this->response);
         ob_end_clean();
-        $this->assertEquals(StatusCodes::ERROR, $status);
+        $this->assertSame(StatusCodes::ERROR, $status);
     }
 
     /**
@@ -118,14 +118,14 @@ class KernelTest extends \PHPUnit\Framework\TestCase
         // Test with short option
         ob_start();
         $status = $this->kernel->handle('holiday birthday -y', $this->response);
-        $this->assertEquals('Happy birthday!', ob_get_clean());
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame('Happy birthday!', ob_get_clean());
+        $this->assertSame(StatusCodes::OK, $status);
 
         // Test with long option
         ob_start();
         $status = $this->kernel->handle('holiday Easter --yell=no', $this->response);
-        $this->assertEquals('Happy Easter', ob_get_clean());
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame('Happy Easter', ob_get_clean());
+        $this->assertSame(StatusCodes::OK, $status);
     }
 
     /**
@@ -136,7 +136,7 @@ class KernelTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $status = $this->kernel->handle('fake', $this->response);
         ob_get_clean();
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame(StatusCodes::OK, $status);
     }
 
     /**
@@ -146,8 +146,8 @@ class KernelTest extends \PHPUnit\Framework\TestCase
     {
         ob_start();
         $status = $this->kernel->handle('mockcommand', $this->response);
-        $this->assertEquals('foo', ob_get_clean());
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame('foo', ob_get_clean());
+        $this->assertSame(StatusCodes::OK, $status);
     }
 
     /**
@@ -159,12 +159,12 @@ class KernelTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $status = $this->kernel->handle('-v', $this->response);
         ob_get_clean();
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame(StatusCodes::OK, $status);
 
         // Try with long name
         ob_start();
         $status = $this->kernel->handle('--version', $this->response);
         ob_get_clean();
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame(StatusCodes::OK, $status);
     }
 }

--- a/src/Opulence/Console/Tests/Prompts/PromptTest.php
+++ b/src/Opulence/Console/Tests/Prompts/PromptTest.php
@@ -49,8 +49,8 @@ class PromptTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $answer = $prompt->ask($question, $this->response);
         $questionText = ob_get_clean();
-        $this->assertEquals("\033[37;44m{$question->getText()}\033[39;49m", $questionText);
-        $this->assertEquals('Dave', $answer);
+        $this->assertSame("\033[37;44m{$question->getText()}\033[39;49m", $questionText);
+        $this->assertSame('Dave', $answer);
     }
 
     /**
@@ -63,9 +63,9 @@ class PromptTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $answer = $prompt->ask($question, $this->response);
         $questionText = ob_get_clean();
-        $this->assertEquals("\033[37;44m{$question->getText()}\033[39;49m" . PHP_EOL . '  1) foo' . PHP_EOL . '  2) bar' . PHP_EOL . '  > ',
+        $this->assertSame("\033[37;44m{$question->getText()}\033[39;49m" . PHP_EOL . '  1) foo' . PHP_EOL . '  2) bar' . PHP_EOL . '  > ',
             $questionText);
-        $this->assertEquals('bar', $answer);
+        $this->assertSame('bar', $answer);
     }
 
     /**
@@ -78,9 +78,9 @@ class PromptTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $answer = $prompt->ask($question, $this->response);
         $questionText = ob_get_clean();
-        $this->assertEquals("\033[37;44m{$question->getText()}\033[39;49m" . PHP_EOL . '  a) b' . PHP_EOL . '  c) d' . PHP_EOL . '  > ',
+        $this->assertSame("\033[37;44m{$question->getText()}\033[39;49m" . PHP_EOL . '  a) b' . PHP_EOL . '  c) d' . PHP_EOL . '  > ',
             $questionText);
-        $this->assertEquals('d', $answer);
+        $this->assertSame('d', $answer);
     }
 
     /**
@@ -94,9 +94,9 @@ class PromptTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $answer = $prompt->ask($question, $this->response);
         $questionText = ob_get_clean();
-        $this->assertEquals("\033[37;44m{$question->getText()}\033[39;49m" . PHP_EOL . '  1) foo' . PHP_EOL . '  2) bar' . PHP_EOL . '  : ',
+        $this->assertSame("\033[37;44m{$question->getText()}\033[39;49m" . PHP_EOL . '  1) foo' . PHP_EOL . '  2) bar' . PHP_EOL . '  : ',
             $questionText);
-        $this->assertEquals('foo', $answer);
+        $this->assertSame('foo', $answer);
     }
 
     /**
@@ -109,8 +109,8 @@ class PromptTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $answer = $prompt->ask($question, $this->response);
         $questionText = ob_get_clean();
-        $this->assertEquals("\033[37;44m{$question->getText()}\033[39;49m", $questionText);
-        $this->assertEquals('Dave', $answer);
+        $this->assertSame("\033[37;44m{$question->getText()}\033[39;49m", $questionText);
+        $this->assertSame('Dave', $answer);
     }
 
     /**
@@ -163,8 +163,8 @@ class PromptTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $answer = $prompt->ask($question, $this->response);
         $questionText = ob_get_clean();
-        $this->assertEquals("\033[37;44m{$question->getText()}\033[39;49m", $questionText);
-        $this->assertEquals('unknown', $answer);
+        $this->assertSame("\033[37;44m{$question->getText()}\033[39;49m", $questionText);
+        $this->assertSame('unknown', $answer);
     }
 
     /**

--- a/src/Opulence/Console/Tests/Prompts/Questions/MultipleChoiceTest.php
+++ b/src/Opulence/Console/Tests/Prompts/Questions/MultipleChoiceTest.php
@@ -104,9 +104,9 @@ class MultipleChoiceTest extends \PHPUnit\Framework\TestCase
      */
     public function testFormattingSingleAnswer()
     {
-        $this->assertEquals('foo', $this->indexedChoiceQuestion->formatAnswer(1));
-        $this->assertEquals('bar', $this->indexedChoiceQuestion->formatAnswer(2));
-        $this->assertEquals('baz', $this->indexedChoiceQuestion->formatAnswer(3));
+        $this->assertSame('foo', $this->indexedChoiceQuestion->formatAnswer(1));
+        $this->assertSame('bar', $this->indexedChoiceQuestion->formatAnswer(2));
+        $this->assertSame('baz', $this->indexedChoiceQuestion->formatAnswer(3));
     }
 
     /**
@@ -114,12 +114,12 @@ class MultipleChoiceTest extends \PHPUnit\Framework\TestCase
      */
     public function testFormattingStringAnswer()
     {
-        $this->assertEquals('foo', $this->indexedChoiceQuestion->formatAnswer('1'));
-        $this->assertEquals('bar', $this->indexedChoiceQuestion->formatAnswer('2'));
-        $this->assertEquals('baz', $this->indexedChoiceQuestion->formatAnswer('3'));
-        $this->assertEquals('b', $this->keyedChoiceQuestion->formatAnswer('a'));
-        $this->assertEquals('d', $this->keyedChoiceQuestion->formatAnswer('c'));
-        $this->assertEquals('f', $this->keyedChoiceQuestion->formatAnswer('e'));
+        $this->assertSame('foo', $this->indexedChoiceQuestion->formatAnswer('1'));
+        $this->assertSame('bar', $this->indexedChoiceQuestion->formatAnswer('2'));
+        $this->assertSame('baz', $this->indexedChoiceQuestion->formatAnswer('3'));
+        $this->assertSame('b', $this->keyedChoiceQuestion->formatAnswer('a'));
+        $this->assertSame('d', $this->keyedChoiceQuestion->formatAnswer('c'));
+        $this->assertSame('f', $this->keyedChoiceQuestion->formatAnswer('e'));
     }
 
     /**
@@ -211,7 +211,7 @@ class MultipleChoiceTest extends \PHPUnit\Framework\TestCase
     public function testSettingAnswerLineString()
     {
         $this->indexedChoiceQuestion->setAnswerLineString('foo');
-        $this->assertEquals('foo', $this->indexedChoiceQuestion->getAnswerLineString());
+        $this->assertSame('foo', $this->indexedChoiceQuestion->getAnswerLineString());
     }
 
     /**

--- a/src/Opulence/Console/Tests/Prompts/Questions/QuestionTest.php
+++ b/src/Opulence/Console/Tests/Prompts/Questions/QuestionTest.php
@@ -33,7 +33,7 @@ class QuestionTest extends \PHPUnit\Framework\TestCase
      */
     public function testFormattingAnswer()
     {
-        $this->assertEquals('foo', $this->question->formatAnswer('foo'));
+        $this->assertSame('foo', $this->question->formatAnswer('foo'));
     }
 
     /**
@@ -41,7 +41,7 @@ class QuestionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingDefaultResponse()
     {
-        $this->assertEquals('foo', $this->question->getDefaultAnswer());
+        $this->assertSame('foo', $this->question->getDefaultAnswer());
     }
 
     /**
@@ -49,6 +49,6 @@ class QuestionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingQuestion()
     {
-        $this->assertEquals('Dummy question', $this->question->getText());
+        $this->assertSame('Dummy question', $this->question->getText());
     }
 }

--- a/src/Opulence/Console/Tests/Requests/ArgumentTest.php
+++ b/src/Opulence/Console/Tests/Requests/ArgumentTest.php
@@ -78,7 +78,7 @@ class ArgumentTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingDefaultValue()
     {
-        $this->assertEquals('bar', $this->argument->getDefaultValue());
+        $this->assertSame('bar', $this->argument->getDefaultValue());
     }
 
     /**
@@ -86,7 +86,7 @@ class ArgumentTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingDescription()
     {
-        $this->assertEquals('Foo argument', $this->argument->getDescription());
+        $this->assertSame('Foo argument', $this->argument->getDescription());
     }
 
     /**
@@ -94,7 +94,7 @@ class ArgumentTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingName()
     {
-        $this->assertEquals('foo', $this->argument->getName());
+        $this->assertSame('foo', $this->argument->getName());
     }
 
     /**

--- a/src/Opulence/Console/Tests/Requests/OptionTest.php
+++ b/src/Opulence/Console/Tests/Requests/OptionTest.php
@@ -77,7 +77,7 @@ class OptionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingDefaultValue()
     {
-        $this->assertEquals('bar', $this->option->getDefaultValue());
+        $this->assertSame('bar', $this->option->getDefaultValue());
     }
 
     /**
@@ -85,7 +85,7 @@ class OptionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingDescription()
     {
-        $this->assertEquals('Foo option', $this->option->getDescription());
+        $this->assertSame('Foo option', $this->option->getDescription());
     }
 
     /**
@@ -93,7 +93,7 @@ class OptionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingName()
     {
-        $this->assertEquals('foo', $this->option->getName());
+        $this->assertSame('foo', $this->option->getName());
     }
 
     /**
@@ -101,7 +101,7 @@ class OptionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingShortName()
     {
-        $this->assertEquals('f', $this->option->getShortName());
+        $this->assertSame('f', $this->option->getShortName());
     }
 
     /**

--- a/src/Opulence/Console/Tests/Requests/Parsers/ArgvParserTest.php
+++ b/src/Opulence/Console/Tests/Requests/Parsers/ArgvParserTest.php
@@ -44,10 +44,10 @@ class ArgvParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingArgumentsAndOptions()
     {
         $request = $this->parser->parse(['apex', 'foo', 'bar', '-r', '--name=dave']);
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals(['bar'], $request->getArgumentValues());
         $this->assertNull($request->getOptionValue('r'));
-        $this->assertEquals('dave', $request->getOptionValue('name'));
+        $this->assertSame('dave', $request->getOptionValue('name'));
     }
 
     /**
@@ -57,10 +57,10 @@ class ArgvParserTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['argv'] = ['apex', 'foo', 'bar', '-r', '--name=dave'];
         $request = $this->parser->parse(null);
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals(['bar'], $request->getArgumentValues());
         $this->assertNull($request->getOptionValue('r'));
-        $this->assertEquals('dave', $request->getOptionValue('name'));
+        $this->assertSame('dave', $request->getOptionValue('name'));
     }
 
     /**

--- a/src/Opulence/Console/Tests/Requests/Parsers/ArrayListParserTest.php
+++ b/src/Opulence/Console/Tests/Requests/Parsers/ArrayListParserTest.php
@@ -50,10 +50,10 @@ class ArrayListParserTest extends \PHPUnit\Framework\TestCase
             'name' => 'foo',
             'options' => ['--name=dave', '-r']
         ]);
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals([], $request->getArgumentValues());
         $this->assertNull($request->getOptionValue('r'));
-        $this->assertEquals('dave', $request->getOptionValue('name'));
+        $this->assertSame('dave', $request->getOptionValue('name'));
     }
 
     /**
@@ -65,7 +65,7 @@ class ArrayListParserTest extends \PHPUnit\Framework\TestCase
             'name' => 'foo',
             'arguments' => ['bar']
         ]);
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals(['bar'], $request->getArgumentValues());
         $this->assertEquals([], $request->getOptionValues());
     }
@@ -80,10 +80,10 @@ class ArrayListParserTest extends \PHPUnit\Framework\TestCase
             'arguments' => ['bar'],
             'options' => ['--name=dave', '-r']
         ]);
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals(['bar'], $request->getArgumentValues());
         $this->assertNull($request->getOptionValue('r'));
-        $this->assertEquals('dave', $request->getOptionValue('name'));
+        $this->assertSame('dave', $request->getOptionValue('name'));
     }
 
     /**
@@ -94,7 +94,7 @@ class ArrayListParserTest extends \PHPUnit\Framework\TestCase
         $request = $this->parser->parse([
             'name' => 'mycommand'
         ]);
-        $this->assertEquals('mycommand', $request->getCommandName());
+        $this->assertSame('mycommand', $request->getCommandName());
     }
 
     /**

--- a/src/Opulence/Console/Tests/Requests/Parsers/StringParserTest.php
+++ b/src/Opulence/Console/Tests/Requests/Parsers/StringParserTest.php
@@ -44,10 +44,10 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingArgumentShortOptionLongOption()
     {
         $request = $this->parser->parse('foo bar -r --name=dave');
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals(['bar'], $request->getArgumentValues());
         $this->assertNull($request->getOptionValue('r'));
-        $this->assertEquals('dave', $request->getOptionValue('name'));
+        $this->assertSame('dave', $request->getOptionValue('name'));
     }
 
     /**
@@ -56,7 +56,7 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingArrayLongOptionWithEqualsSign()
     {
         $request = $this->parser->parse('foo --name=dave --name=young');
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals([], $request->getArgumentValues());
         $this->assertEquals(['dave', 'young'], $request->getOptionValue('name'));
     }
@@ -67,7 +67,7 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingArrayLongOptionWithoutEqualsSign()
     {
         $request = $this->parser->parse('foo --name dave --name young');
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals([], $request->getArgumentValues());
         $this->assertEquals(['dave', 'young'], $request->getOptionValue('name'));
     }
@@ -78,7 +78,7 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingCommandName()
     {
         $request = $this->parser->parse('foo');
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals([], $request->getArgumentValues());
         $this->assertEquals([], $request->getOptionValues());
     }
@@ -89,9 +89,9 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingLongOptionWithEqualsSign()
     {
         $request = $this->parser->parse('foo --name=dave');
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals([], $request->getArgumentValues());
-        $this->assertEquals('dave', $request->getOptionValue('name'));
+        $this->assertSame('dave', $request->getOptionValue('name'));
     }
 
     /**
@@ -100,9 +100,9 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingLongOptionWithoutEqualsSign()
     {
         $request = $this->parser->parse('foo --name dave');
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals([], $request->getArgumentValues());
-        $this->assertEquals('dave', $request->getOptionValue('name'));
+        $this->assertSame('dave', $request->getOptionValue('name'));
     }
 
     /**
@@ -111,9 +111,9 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingLongOptionWithoutEqualsSignWithArgumentAfter()
     {
         $request = $this->parser->parse('foo --name dave bar');
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals(['bar'], $request->getArgumentValues());
-        $this->assertEquals('dave', $request->getOptionValue('name'));
+        $this->assertSame('dave', $request->getOptionValue('name'));
     }
 
     /**
@@ -122,10 +122,10 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingLongOptionWithoutEqualsSignWithQuotedValue()
     {
         $request = $this->parser->parse("foo --first 'dave' --last=\"young\"");
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals([], $request->getArgumentValues());
-        $this->assertEquals('dave', $request->getOptionValue('first'));
-        $this->assertEquals('young', $request->getOptionValue('last'));
+        $this->assertSame('dave', $request->getOptionValue('first'));
+        $this->assertSame('young', $request->getOptionValue('last'));
     }
 
     /**
@@ -134,7 +134,7 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingMultipleArgument()
     {
         $request = $this->parser->parse('foo bar baz blah');
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals(['bar', 'baz', 'blah'], $request->getArgumentValues());
         $this->assertEquals([], $request->getOptionValues());
     }
@@ -145,7 +145,7 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingMultipleSeparateShortOptions()
     {
         $request = $this->parser->parse('foo -r -f -d');
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertNull($request->getOptionValue('r'));
         $this->assertNull($request->getOptionValue('f'));
         $this->assertNull($request->getOptionValue('d'));
@@ -158,7 +158,7 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingMultipleShortOptions()
     {
         $request = $this->parser->parse('foo -rfd');
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertNull($request->getOptionValue('r'));
         $this->assertNull($request->getOptionValue('f'));
         $this->assertNull($request->getOptionValue('d'));
@@ -171,7 +171,7 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingSingleArgument()
     {
         $request = $this->parser->parse('foo bar');
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals(['bar'], $request->getArgumentValues());
         $this->assertEquals([], $request->getOptionValues());
     }
@@ -182,7 +182,7 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingSingleShortOption()
     {
         $request = $this->parser->parse('foo -r');
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertNull($request->getOptionValue('r'));
         $this->assertEquals([], $request->getArgumentValues());
     }
@@ -193,7 +193,7 @@ class StringParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingTwoConsecutiveLongOptions()
     {
         $request = $this->parser->parse('foo --bar --baz');
-        $this->assertEquals('foo', $request->getCommandName());
+        $this->assertSame('foo', $request->getCommandName());
         $this->assertEquals([], $request->getArgumentValues());
         $this->assertEquals(null, $request->getOptionValue('bar'));
         $this->assertEquals(null, $request->getOptionValue('baz'));

--- a/src/Opulence/Console/Tests/Requests/RequestTest.php
+++ b/src/Opulence/Console/Tests/Requests/RequestTest.php
@@ -35,7 +35,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testAddingMultipleValuesForOption()
     {
         $this->request->addOptionValue('foo', 'bar');
-        $this->assertEquals('bar', $this->request->getOptionValue('foo'));
+        $this->assertSame('bar', $this->request->getOptionValue('foo'));
         $this->request->addOptionValue('foo', 'baz');
         $this->assertEquals(['bar', 'baz'], $this->request->getOptionValue('foo'));
     }
@@ -84,7 +84,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testGettingCommandName()
     {
         $this->request->setCommandName('foo');
-        $this->assertEquals('foo', $this->request->getCommandName());
+        $this->assertSame('foo', $this->request->getCommandName());
     }
 
     /**
@@ -102,6 +102,6 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testGettingOption()
     {
         $this->request->addOptionValue('foo', 'bar');
-        $this->assertEquals('bar', $this->request->getOptionValue('foo'));
+        $this->assertSame('bar', $this->request->getOptionValue('foo'));
     }
 }

--- a/src/Opulence/Console/Tests/Responses/Compilers/CompilerTest.php
+++ b/src/Opulence/Console/Tests/Responses/Compilers/CompilerTest.php
@@ -40,7 +40,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->compiler->registerElement('foo', new Style('green', 'white'));
         $this->compiler->registerElement('bar', new Style('cyan'));
         $expectedOutput = "\033[32;47mbaz\033[39;49m\033[36mblah\033[39m";
-        $this->assertEquals(
+        $this->assertSame(
             $expectedOutput,
             $this->compiler->compile('<foo>baz</foo><bar>blah</bar>')
         );
@@ -54,7 +54,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->compiler->registerElement('foo', new Style('green', 'white'));
         $this->compiler->registerElement('bar', new Style('cyan'));
         $expectedOutput = '';
-        $this->assertEquals(
+        $this->assertSame(
             $expectedOutput,
             $this->compiler->compile('<foo></foo>')
         );
@@ -68,7 +68,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->compiler->setStyled(false);
         $this->compiler->registerElement('foo', new Style('green', 'white'));
         $this->compiler->registerElement('bar', new Style('cyan'));
-        $this->assertEquals('bazblah', $this->compiler->compile('<foo>baz</foo><bar>blah</bar>'));
+        $this->assertSame('bazblah', $this->compiler->compile('<foo>baz</foo><bar>blah</bar>'));
     }
 
     /**
@@ -78,7 +78,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
     {
         $this->compiler->registerElement('foo', new Style('green'));
         $expectedOutput = '<bar>';
-        $this->assertEquals($expectedOutput, $this->compiler->compile('\\<bar>'));
+        $this->assertSame($expectedOutput, $this->compiler->compile('\\<bar>'));
     }
 
     /**
@@ -88,7 +88,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
     {
         $this->compiler->registerElement('foo', new Style('green'));
         $expectedOutput = "\033[32m<bar>\033[39m";
-        $this->assertEquals($expectedOutput, $this->compiler->compile('<foo>\\<bar></foo>'));
+        $this->assertSame($expectedOutput, $this->compiler->compile('<foo>\\<bar></foo>'));
     }
 
     /**
@@ -99,7 +99,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->compiler->registerElement('foo', new Style('green', 'white'));
         $this->compiler->registerElement('bar', new Style('cyan'));
         $expectedOutput = "\033[32;47m\033[36mbaz\033[39m\033[39;49m";
-        $this->assertEquals(
+        $this->assertSame(
             $expectedOutput,
             $this->compiler->compile('<foo><bar>baz</bar></foo>')
         );
@@ -113,7 +113,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->compiler->registerElement('foo', new Style('green', 'white'));
         $this->compiler->registerElement('bar', new Style('cyan'));
         $expectedOutput = '';
-        $this->assertEquals(
+        $this->assertSame(
             $expectedOutput,
             $this->compiler->compile('<foo><bar></bar></foo>')
         );
@@ -127,7 +127,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $this->compiler->registerElement('foo', new Style('green', 'white'));
         $this->compiler->registerElement('bar', new Style('cyan'));
         $expectedOutput = "\033[32;47mbar\033[39;49m\033[32;47m\033[36mblah\033[39m\033[39;49m\033[32;47mbaz\033[39;49m";
-        $this->assertEquals(
+        $this->assertSame(
             $expectedOutput,
             $this->compiler->compile('<foo>bar<bar>blah</bar>baz</foo>')
         );
@@ -139,7 +139,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
     public function testCompilingPlainText()
     {
         $expectedOutput = 'foobar';
-        $this->assertEquals(
+        $this->assertSame(
             $expectedOutput,
             $this->compiler->compile('foobar')
         );
@@ -152,7 +152,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
     {
         $this->compiler->registerElement('foo', new Style('green'));
         $expectedOutput = "\033[32mbar\033[39m";
-        $this->assertEquals($expectedOutput, $this->compiler->compile('<foo>bar</foo>'));
+        $this->assertSame($expectedOutput, $this->compiler->compile('<foo>bar</foo>'));
     }
 
     /**

--- a/src/Opulence/Console/Tests/Responses/Compilers/Elements/StyleTest.php
+++ b/src/Opulence/Console/Tests/Responses/Compilers/Elements/StyleTest.php
@@ -58,7 +58,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
     public function testFormattingEmptyString()
     {
         $styles = new Style(Colors::RED, Colors::GREEN, [TextStyles::BOLD, TextStyles::UNDERLINE, TextStyles::BLINK]);
-        $this->assertEquals('', $styles->format(''));
+        $this->assertSame('', $styles->format(''));
     }
 
     /**
@@ -67,7 +67,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
     public function testFormattingStringWithAllStyles()
     {
         $styles = new Style(Colors::RED, Colors::GREEN, [TextStyles::BOLD, TextStyles::UNDERLINE, TextStyles::BLINK]);
-        $this->assertEquals("\033[31;42;1;4;5mfoo\033[39;49;22;24;25m", $styles->format('foo'));
+        $this->assertSame("\033[31;42;1;4;5mfoo\033[39;49;22;24;25m", $styles->format('foo'));
     }
 
     /**
@@ -76,7 +76,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
     public function testFormattingStringWithoutStyles()
     {
         $styles = new Style();
-        $this->assertEquals('foo', $styles->format('foo'));
+        $this->assertSame('foo', $styles->format('foo'));
     }
 
     /**
@@ -95,8 +95,8 @@ class StyleTest extends \PHPUnit\Framework\TestCase
     public function testPassingColorsInConstructor()
     {
         $style = new Style(Colors::BLUE, Colors::GREEN);
-        $this->assertEquals(Colors::BLUE, $style->getForegroundColor());
-        $this->assertEquals(Colors::GREEN, $style->getBackgroundColor());
+        $this->assertSame(Colors::BLUE, $style->getForegroundColor());
+        $this->assertSame(Colors::GREEN, $style->getBackgroundColor());
     }
 
     /**
@@ -127,7 +127,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
     {
         $style = new Style();
         $style->setBackgroundColor(Colors::GREEN);
-        $this->assertEquals(Colors::GREEN, $style->getBackgroundColor());
+        $this->assertSame(Colors::GREEN, $style->getBackgroundColor());
     }
 
     /**
@@ -137,7 +137,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
     {
         $style = new Style();
         $style->setForegroundColor(Colors::BLUE);
-        $this->assertEquals(Colors::BLUE, $style->getForegroundColor());
+        $this->assertSame(Colors::BLUE, $style->getForegroundColor());
     }
 
     /**

--- a/src/Opulence/Console/Tests/Responses/Compilers/Lexers/Tokens/TokenTest.php
+++ b/src/Opulence/Console/Tests/Responses/Compilers/Lexers/Tokens/TokenTest.php
@@ -34,7 +34,7 @@ class TokenTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingPosition()
     {
-        $this->assertEquals(24, $this->token->getPosition());
+        $this->assertSame(24, $this->token->getPosition());
     }
 
     /**
@@ -42,7 +42,7 @@ class TokenTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingType()
     {
-        $this->assertEquals(TokenTypes::T_WORD, $this->token->getType());
+        $this->assertSame(TokenTypes::T_WORD, $this->token->getType());
     }
 
     /**
@@ -50,6 +50,6 @@ class TokenTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingValue()
     {
-        $this->assertEquals('foo', $this->token->getValue());
+        $this->assertSame('foo', $this->token->getValue());
     }
 }

--- a/src/Opulence/Console/Tests/Responses/Compilers/MockCompilerTest.php
+++ b/src/Opulence/Console/Tests/Responses/Compilers/MockCompilerTest.php
@@ -24,7 +24,7 @@ class MockCompilerTest extends \PHPUnit\Framework\TestCase
     {
         $compiler = new MockCompiler();
         $compiler->setStyled(true);
-        $this->assertEquals('<foo>bar</foo>', $compiler->compile('<foo>bar</foo>'));
+        $this->assertSame('<foo>bar</foo>', $compiler->compile('<foo>bar</foo>'));
     }
 
     /**
@@ -34,6 +34,6 @@ class MockCompilerTest extends \PHPUnit\Framework\TestCase
     {
         $compiler = new MockCompiler();
         $compiler->setStyled(false);
-        $this->assertEquals('<foo>bar</foo>', $compiler->compile('<foo>bar</foo>'));
+        $this->assertSame('<foo>bar</foo>', $compiler->compile('<foo>bar</foo>'));
     }
 }

--- a/src/Opulence/Console/Tests/Responses/Compilers/Parsers/Nodes/NodeTest.php
+++ b/src/Opulence/Console/Tests/Responses/Compilers/Parsers/Nodes/NodeTest.php
@@ -59,6 +59,6 @@ class NodeTest extends \PHPUnit\Framework\TestCase
     public function testGettingValue()
     {
         $node = new Node('foo');
-        $this->assertEquals('foo', $node->getValue());
+        $this->assertSame('foo', $node->getValue());
     }
 }

--- a/src/Opulence/Console/Tests/Responses/Formatters/CommandFormatterTest.php
+++ b/src/Opulence/Console/Tests/Responses/Formatters/CommandFormatterTest.php
@@ -59,7 +59,7 @@ class CommandFormatterTest extends \PHPUnit\Framework\TestCase
             ArgumentTypes::IS_ARRAY,
             'Blah argument'
         ));
-        $this->assertEquals('foo [--help|-h] bar [baz] blah1...blahN', $this->formatter->format($command));
+        $this->assertSame('foo [--help|-h] bar [baz] blah1...blahN', $this->formatter->format($command));
     }
 
     /**
@@ -78,7 +78,7 @@ class CommandFormatterTest extends \PHPUnit\Framework\TestCase
             ArgumentTypes::REQUIRED,
             'Baz argument'
         ));
-        $this->assertEquals('foo [--help|-h] bar baz', $this->formatter->format($command));
+        $this->assertSame('foo [--help|-h] bar baz', $this->formatter->format($command));
     }
 
     /**
@@ -87,7 +87,7 @@ class CommandFormatterTest extends \PHPUnit\Framework\TestCase
     public function testFormattingCommandWithNoArgumentsOrOptions()
     {
         $command = new SimpleCommand('foo', 'Foo command');
-        $this->assertEquals('foo [--help|-h]', $this->formatter->format($command));
+        $this->assertSame('foo [--help|-h]', $this->formatter->format($command));
     }
 
     /**
@@ -101,7 +101,7 @@ class CommandFormatterTest extends \PHPUnit\Framework\TestCase
             ArgumentTypes::REQUIRED,
             'Bar argument'
         ));
-        $this->assertEquals('foo [--help|-h] bar', $this->formatter->format($command));
+        $this->assertSame('foo [--help|-h] bar', $this->formatter->format($command));
     }
 
     /**
@@ -117,7 +117,7 @@ class CommandFormatterTest extends \PHPUnit\Framework\TestCase
             'Bar option',
             'yes'
         ));
-        $this->assertEquals('foo [--help|-h] [--bar=yes|-b]', $this->formatter->format($command));
+        $this->assertSame('foo [--help|-h] [--bar=yes|-b]', $this->formatter->format($command));
     }
 
     /**
@@ -133,7 +133,7 @@ class CommandFormatterTest extends \PHPUnit\Framework\TestCase
             'Bar option',
             'yes'
         ));
-        $this->assertEquals('foo [--help|-h] [--bar=yes]', $this->formatter->format($command));
+        $this->assertSame('foo [--help|-h] [--bar=yes]', $this->formatter->format($command));
     }
 
     /**
@@ -148,7 +148,7 @@ class CommandFormatterTest extends \PHPUnit\Framework\TestCase
             OptionTypes::NO_VALUE,
             'Bar option'
         ));
-        $this->assertEquals('foo [--help|-h] [--bar]', $this->formatter->format($command));
+        $this->assertSame('foo [--help|-h] [--bar]', $this->formatter->format($command));
     }
 
     /**
@@ -162,7 +162,7 @@ class CommandFormatterTest extends \PHPUnit\Framework\TestCase
             ArgumentTypes::OPTIONAL,
             'Bar argument'
         ));
-        $this->assertEquals('foo [--help|-h] [bar]', $this->formatter->format($command));
+        $this->assertSame('foo [--help|-h] [bar]', $this->formatter->format($command));
     }
 
     /**
@@ -176,6 +176,6 @@ class CommandFormatterTest extends \PHPUnit\Framework\TestCase
             ArgumentTypes::IS_ARRAY | ArgumentTypes::OPTIONAL,
             'Blah argument'
         ));
-        $this->assertEquals('foo [--help|-h] [blah1]...[blahN]', $this->formatter->format($command));
+        $this->assertSame('foo [--help|-h] [blah1]...[blahN]', $this->formatter->format($command));
     }
 }

--- a/src/Opulence/Console/Tests/Responses/Formatters/PaddingFormatterTest.php
+++ b/src/Opulence/Console/Tests/Responses/Formatters/PaddingFormatterTest.php
@@ -43,7 +43,7 @@ class PaddingFormatterTest extends \PHPUnit\Framework\TestCase
         $formattedText = $this->formatter->format($rows, function ($row) {
             return $row[0] . '-' . $row[1];
         });
-        $this->assertEquals('a++-b++' . PHP_EOL . 'cd+-ee+' . PHP_EOL . 'fg+-hhh' . PHP_EOL . 'ijk-ll+',
+        $this->assertSame('a++-b++' . PHP_EOL . 'cd+-ee+' . PHP_EOL . 'fg+-hhh' . PHP_EOL . 'ijk-ll+',
             $formattedText);
     }
 
@@ -62,7 +62,7 @@ class PaddingFormatterTest extends \PHPUnit\Framework\TestCase
         $formattedText = $this->formatter->format($rows, function ($row) {
             return $row[0];
         });
-        $this->assertEquals('a++' . PHP_EOL . 'cd+' . PHP_EOL . 'fg+' . PHP_EOL . 'ijk', $formattedText);
+        $this->assertSame('a++' . PHP_EOL . 'cd+' . PHP_EOL . 'fg+' . PHP_EOL . 'ijk', $formattedText);
     }
 
     /**
@@ -80,7 +80,7 @@ class PaddingFormatterTest extends \PHPUnit\Framework\TestCase
         $formattedText = $this->formatter->format($rows, function ($row) {
             return $row[0] . '-' . $row[1];
         });
-        $this->assertEquals('a  -b  <br>cd -ee <br>fg -hhh<br>ijk-ll ', $formattedText);
+        $this->assertSame('a  -b  <br>cd -ee <br>fg -hhh<br>ijk-ll ', $formattedText);
     }
 
     /**
@@ -98,7 +98,7 @@ class PaddingFormatterTest extends \PHPUnit\Framework\TestCase
         $formattedText = $this->formatter->format($rows, function ($row) {
             return $row[0];
         });
-        $this->assertEquals('a  <br>cd <br>fg <br>ijk', $formattedText);
+        $this->assertSame('a  <br>cd <br>fg <br>ijk', $formattedText);
     }
 
     /**
@@ -107,7 +107,7 @@ class PaddingFormatterTest extends \PHPUnit\Framework\TestCase
     public function testGettingEOLChar()
     {
         $this->formatter->setEolChar('foo');
-        $this->assertEquals('foo', $this->formatter->getEolChar());
+        $this->assertSame('foo', $this->formatter->getEolChar());
     }
 
     /**
@@ -147,14 +147,14 @@ class PaddingFormatterTest extends \PHPUnit\Framework\TestCase
         $formattedRows = $this->formatter->format($rows, function ($row) {
             return $row[0] . '-' . $row[1];
         });
-        $this->assertEquals('a  -b  ' . PHP_EOL . 'cd -ee ' . PHP_EOL . 'fg -hhh' . PHP_EOL . 'ijk-ll ',
+        $this->assertSame('a  -b  ' . PHP_EOL . 'cd -ee ' . PHP_EOL . 'fg -hhh' . PHP_EOL . 'ijk-ll ',
             $formattedRows);
         // Format with the padding before the string
         $this->formatter->setPadAfter(false);
         $formattedRows = $this->formatter->format($rows, function ($row) {
             return $row[0] . '-' . $row[1];
         });
-        $this->assertEquals('  a-  b' . PHP_EOL . ' cd- ee' . PHP_EOL . ' fg-hhh' . PHP_EOL . 'ijk- ll',
+        $this->assertSame('  a-  b' . PHP_EOL . ' cd- ee' . PHP_EOL . ' fg-hhh' . PHP_EOL . 'ijk- ll',
             $formattedRows);
     }
 
@@ -163,7 +163,7 @@ class PaddingFormatterTest extends \PHPUnit\Framework\TestCase
      */
     public function testPaddingEmptyArray()
     {
-        $this->assertEquals('', $this->formatter->format([], function ($row) {
+        $this->assertSame('', $this->formatter->format([], function ($row) {
             return $row[0];
         }));
     }
@@ -173,7 +173,7 @@ class PaddingFormatterTest extends \PHPUnit\Framework\TestCase
      */
     public function testPaddingSingleArray()
     {
-        $this->assertEquals('foo' . PHP_EOL . 'bar', $this->formatter->format(['  foo  ', 'bar'], function ($row) {
+        $this->assertSame('foo' . PHP_EOL . 'bar', $this->formatter->format(['  foo  ', 'bar'], function ($row) {
             return $row[0];
         }));
     }
@@ -183,7 +183,7 @@ class PaddingFormatterTest extends \PHPUnit\Framework\TestCase
      */
     public function testPaddingSingleString()
     {
-        $this->assertEquals('foo', $this->formatter->format(['  foo  '], function ($row) {
+        $this->assertSame('foo', $this->formatter->format(['  foo  '], function ($row) {
             return $row[0];
         }));
     }
@@ -204,12 +204,12 @@ class PaddingFormatterTest extends \PHPUnit\Framework\TestCase
         $formattedRows = $this->formatter->format($rows, function ($row) {
             return $row[0];
         });
-        $this->assertEquals('a  ' . PHP_EOL . 'cd ' . PHP_EOL . 'fg ' . PHP_EOL . 'ijk', $formattedRows);
+        $this->assertSame('a  ' . PHP_EOL . 'cd ' . PHP_EOL . 'fg ' . PHP_EOL . 'ijk', $formattedRows);
         // Format with the padding before the string
         $this->formatter->setPadAfter(false);
         $formattedRows = $this->formatter->format($rows, function ($row) {
             return $row[0];
         });
-        $this->assertEquals('  a' . PHP_EOL . ' cd' . PHP_EOL . ' fg' . PHP_EOL . 'ijk', $formattedRows);
+        $this->assertSame('  a' . PHP_EOL . ' cd' . PHP_EOL . ' fg' . PHP_EOL . 'ijk', $formattedRows);
     }
 }

--- a/src/Opulence/Console/Tests/Responses/Formatters/TableFormatterTest.php
+++ b/src/Opulence/Console/Tests/Responses/Formatters/TableFormatterTest.php
@@ -50,7 +50,7 @@ class TableFormatterTest extends \PHPUnit\Framework\TestCase
             '+-----+' . PHP_EOL .
             '| a   |' . PHP_EOL .
             '+-----+';
-        $this->assertEquals($expected, $this->formatter->format($rows, $headers));
+        $this->assertSame($expected, $this->formatter->format($rows, $headers));
     }
 
     /**
@@ -63,7 +63,7 @@ class TableFormatterTest extends \PHPUnit\Framework\TestCase
             '+---+----+-----+' . PHP_EOL .
             '| a | bb | ccc |' . PHP_EOL .
             '+---+----+-----+';
-        $this->assertEquals($expected, $this->formatter->format($rows));
+        $this->assertSame($expected, $this->formatter->format($rows));
     }
 
     /**
@@ -76,7 +76,7 @@ class TableFormatterTest extends \PHPUnit\Framework\TestCase
             '+---+' . PHP_EOL .
             '| a |' . PHP_EOL .
             '+---+';
-        $this->assertEquals($expected, $this->formatter->format($rows));
+        $this->assertSame($expected, $this->formatter->format($rows));
     }
 
     /**
@@ -104,7 +104,7 @@ class TableFormatterTest extends \PHPUnit\Framework\TestCase
             'I_ aa_I_ bb_I_   _I<br>' .
             'I_aaa_I_bbb_I_ccc_I<br>' .
             '*=====*=====*=====*';
-        $this->assertEquals($expected, $this->formatter->format($rows, $headers));
+        $this->assertSame($expected, $this->formatter->format($rows, $headers));
     }
 
     /**
@@ -118,7 +118,7 @@ class TableFormatterTest extends \PHPUnit\Framework\TestCase
             '+-----+' . PHP_EOL .
             '|__a__|' . PHP_EOL .
             '+-----+';
-        $this->assertEquals($expected, $this->formatter->format($rows));
+        $this->assertSame($expected, $this->formatter->format($rows));
     }
 
     /**
@@ -148,7 +148,7 @@ class TableFormatterTest extends \PHPUnit\Framework\TestCase
             '| aa  | bb  |     |      |' . PHP_EOL .
             '| aaa | bbb | ccc |      |' . PHP_EOL .
             '+-----+-----+-----+------+';
-        $this->assertEquals($expected, $this->formatter->format($rows, $headers));
+        $this->assertSame($expected, $this->formatter->format($rows, $headers));
     }
 
     /**
@@ -170,7 +170,7 @@ class TableFormatterTest extends \PHPUnit\Framework\TestCase
             '| aa  | bb  |     |' . PHP_EOL .
             '| aaa | bbb | ccc |' . PHP_EOL .
             '+-----+-----+-----+';
-        $this->assertEquals($expected, $this->formatter->format($rows, $headers));
+        $this->assertSame($expected, $this->formatter->format($rows, $headers));
     }
 
     /**
@@ -189,7 +189,7 @@ class TableFormatterTest extends \PHPUnit\Framework\TestCase
             '| aa  | bb  |     |' . PHP_EOL .
             '| aaa | bbb | ccc |' . PHP_EOL .
             '+-----+-----+-----+';
-        $this->assertEquals($expected, $this->formatter->format($rows));
+        $this->assertSame($expected, $this->formatter->format($rows));
     }
 
     /**
@@ -202,6 +202,6 @@ class TableFormatterTest extends \PHPUnit\Framework\TestCase
             '| foo |' . PHP_EOL .
             '| bar |' . PHP_EOL .
             '+-----+';
-        $this->assertEquals($expected, $this->formatter->format(['foo', 'bar']));
+        $this->assertSame($expected, $this->formatter->format(['foo', 'bar']));
     }
 }

--- a/src/Opulence/Console/Tests/Responses/ResponseTest.php
+++ b/src/Opulence/Console/Tests/Responses/ResponseTest.php
@@ -38,7 +38,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     {
         ob_start();
         $this->response->clear();
-        $this->assertEquals(chr(27) . '[2J' . chr(27) . '[;H', ob_get_clean());
+        $this->assertSame(chr(27) . '[2J' . chr(27) . '[;H', ob_get_clean());
     }
 
     /**
@@ -48,7 +48,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     {
         ob_start();
         $this->response->writeln(['foo', 'bar']);
-        $this->assertEquals('foo' . PHP_EOL . 'bar' . PHP_EOL, ob_get_clean());
+        $this->assertSame('foo' . PHP_EOL . 'bar' . PHP_EOL, ob_get_clean());
     }
 
     /**
@@ -58,7 +58,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     {
         ob_start();
         $this->response->write(['foo', 'bar']);
-        $this->assertEquals('foobar', ob_get_clean());
+        $this->assertSame('foobar', ob_get_clean());
     }
 
     /**
@@ -68,7 +68,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     {
         ob_start();
         $this->response->writeln('foo');
-        $this->assertEquals('foo' . PHP_EOL, ob_get_clean());
+        $this->assertSame('foo' . PHP_EOL, ob_get_clean());
     }
 
     /**
@@ -78,7 +78,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     {
         ob_start();
         $this->response->write('foo');
-        $this->assertEquals('foo', ob_get_clean());
+        $this->assertSame('foo', ob_get_clean());
     }
 
     /**
@@ -89,6 +89,6 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $this->response->setStyled(false);
         $this->response->write('<b>foo</b>');
-        $this->assertEquals('foo', ob_get_clean());
+        $this->assertSame('foo', ob_get_clean());
     }
 }

--- a/src/Opulence/Console/Tests/Responses/StreamResponseTest.php
+++ b/src/Opulence/Console/Tests/Responses/StreamResponseTest.php
@@ -40,7 +40,7 @@ class StreamResponseTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingStream()
     {
-        $this->assertTrue(is_resource($this->response->getStream()));
+        $this->assertIsResource($this->response->getStream());
     }
 
     /**
@@ -59,7 +59,7 @@ class StreamResponseTest extends \PHPUnit\Framework\TestCase
     {
         $this->response->write(['foo', 'bar']);
         rewind($this->response->getStream());
-        $this->assertEquals('foobar', stream_get_contents($this->response->getStream()));
+        $this->assertSame('foobar', stream_get_contents($this->response->getStream()));
     }
 
     /**
@@ -69,7 +69,7 @@ class StreamResponseTest extends \PHPUnit\Framework\TestCase
     {
         $this->response->write('foo');
         rewind($this->response->getStream());
-        $this->assertEquals('foo', stream_get_contents($this->response->getStream()));
+        $this->assertSame('foo', stream_get_contents($this->response->getStream()));
     }
 
     /**
@@ -79,7 +79,7 @@ class StreamResponseTest extends \PHPUnit\Framework\TestCase
     {
         $this->response->writeln(['foo', 'bar']);
         rewind($this->response->getStream());
-        $this->assertEquals('foo' . PHP_EOL . 'bar' . PHP_EOL, stream_get_contents($this->response->getStream()));
+        $this->assertSame('foo' . PHP_EOL . 'bar' . PHP_EOL, stream_get_contents($this->response->getStream()));
     }
 
     /**
@@ -89,6 +89,6 @@ class StreamResponseTest extends \PHPUnit\Framework\TestCase
     {
         $this->response->writeln('foo');
         rewind($this->response->getStream());
-        $this->assertEquals('foo' . PHP_EOL, stream_get_contents($this->response->getStream()));
+        $this->assertSame('foo' . PHP_EOL, stream_get_contents($this->response->getStream()));
     }
 }

--- a/src/Opulence/Cryptography/Tests/Encryption/EncrypterTest.php
+++ b/src/Opulence/Cryptography/Tests/Encryption/EncrypterTest.php
@@ -149,7 +149,7 @@ class EncrypterTest extends \PHPUnit\Framework\TestCase
         $encrypter1 = new Encrypter(new Key($key), Ciphers::AES_128_CBC);
         $encryptedValue = $encrypter1->encrypt('foo');
         $encrypter2 = new Encrypter(new Key($key), Ciphers::AES_128_CTR);
-        $this->assertEquals('foo', $encrypter2->decrypt($encryptedValue));
+        $this->assertSame('foo', $encrypter2->decrypt($encryptedValue));
     }
 
     /**
@@ -172,8 +172,8 @@ class EncrypterTest extends \PHPUnit\Framework\TestCase
         $this->assertNotEquals($decryptedValue, $encryptedValueWithPassword);
         $this->assertNotEquals($decryptedValue, $encryptedValueWithKey);
         $this->assertNotEquals($encryptedValueWithPassword, $encryptedValueWithKey);
-        $this->assertEquals($decryptedValue, $this->encrypterWithPassword->decrypt($encryptedValueWithPassword));
-        $this->assertEquals($decryptedValue, $this->encrypterWithKey->decrypt($encryptedValueWithKey));
+        $this->assertSame($decryptedValue, $this->encrypterWithPassword->decrypt($encryptedValueWithPassword));
+        $this->assertSame($decryptedValue, $this->encrypterWithKey->decrypt($encryptedValueWithKey));
     }
 
     /**
@@ -205,7 +205,7 @@ class EncrypterTest extends \PHPUnit\Framework\TestCase
             $decryptedValue = 'foobar';
             $encryptedValue = $encrypter->encrypt($decryptedValue);
             $this->assertNotEquals($decryptedValue, $encryptedValue);
-            $this->assertEquals($decryptedValue, $encrypter->decrypt($encryptedValue));
+            $this->assertSame($decryptedValue, $encrypter->decrypt($encryptedValue));
         }
 
         // Test using keys
@@ -214,7 +214,7 @@ class EncrypterTest extends \PHPUnit\Framework\TestCase
             $decryptedValue = 'foobar';
             $encryptedValue = $encrypter->encrypt($decryptedValue);
             $this->assertNotEquals($decryptedValue, $encryptedValue);
-            $this->assertEquals($decryptedValue, $encrypter->decrypt($encryptedValue));
+            $this->assertSame($decryptedValue, $encrypter->decrypt($encryptedValue));
         }
     }
 

--- a/src/Opulence/Cryptography/Tests/Encryption/Keys/DerivedKeysTest.php
+++ b/src/Opulence/Cryptography/Tests/Encryption/Keys/DerivedKeysTest.php
@@ -33,7 +33,7 @@ class DerivedKeysTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingAuthenticationKey()
     {
-        $this->assertEquals(str_repeat('2', 32), $this->derivedKeys->getAuthenticationKey());
+        $this->assertSame(str_repeat('2', 32), $this->derivedKeys->getAuthenticationKey());
     }
 
     /**
@@ -41,6 +41,6 @@ class DerivedKeysTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingEncryptionKey()
     {
-        $this->assertEquals(str_repeat('1', 32), $this->derivedKeys->getEncryptionKey());
+        $this->assertSame(str_repeat('1', 32), $this->derivedKeys->getEncryptionKey());
     }
 }

--- a/src/Opulence/Cryptography/Tests/Encryption/Keys/KeyTest.php
+++ b/src/Opulence/Cryptography/Tests/Encryption/Keys/KeyTest.php
@@ -25,7 +25,7 @@ class KeyTest extends \PHPUnit\Framework\TestCase
     {
         $value = str_repeat('a', 32);
         $key = new Key($value);
-        $this->assertEquals(SecretTypes::KEY, $key->getType());
-        $this->assertEquals($value, $key->getValue());
+        $this->assertSame(SecretTypes::KEY, $key->getType());
+        $this->assertSame($value, $key->getValue());
     }
 }

--- a/src/Opulence/Cryptography/Tests/Encryption/Keys/PasswordTest.php
+++ b/src/Opulence/Cryptography/Tests/Encryption/Keys/PasswordTest.php
@@ -24,7 +24,7 @@ class PasswordTest extends \PHPUnit\Framework\TestCase
     public function testGettingValue()
     {
         $key = new Password('foo');
-        $this->assertEquals(SecretTypes::PASSWORD, $key->getType());
-        $this->assertEquals('foo', $key->getValue());
+        $this->assertSame(SecretTypes::PASSWORD, $key->getType());
+        $this->assertSame('foo', $key->getValue());
     }
 }

--- a/src/Opulence/Cryptography/Tests/Encryption/Keys/SecretTest.php
+++ b/src/Opulence/Cryptography/Tests/Encryption/Keys/SecretTest.php
@@ -34,7 +34,7 @@ class SecretTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingType()
     {
-        $this->assertEquals(SecretTypes::PASSWORD, $this->secret->getType());
+        $this->assertSame(SecretTypes::PASSWORD, $this->secret->getType());
     }
 
     /**
@@ -42,7 +42,7 @@ class SecretTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingValue()
     {
-        $this->assertEquals('foo', $this->secret->getValue());
+        $this->assertSame('foo', $this->secret->getValue());
     }
 
     /**
@@ -52,6 +52,6 @@ class SecretTest extends \PHPUnit\Framework\TestCase
     {
         $key = str_repeat('a', 32);
         $secret = new Secret(SecretTypes::KEY, $key);
-        $this->assertEquals($key, $secret->getValue());
+        $this->assertSame($key, $secret->getValue());
     }
 }

--- a/src/Opulence/Cryptography/Tests/Hashing/BcryptHasherTest.php
+++ b/src/Opulence/Cryptography/Tests/Hashing/BcryptHasherTest.php
@@ -33,7 +33,7 @@ class BcryptHasherTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingDefaultCost()
     {
-        $this->assertEquals(10, BcryptHasher::DEFAULT_COST);
+        $this->assertSame(10, BcryptHasher::DEFAULT_COST);
     }
 
     /**

--- a/src/Opulence/Databases/Tests/Adapters/Pdo/MySql/DriverTest.php
+++ b/src/Opulence/Databases/Tests/Adapters/Pdo/MySql/DriverTest.php
@@ -29,7 +29,7 @@ class DriverTest extends \PHPUnit\Framework\TestCase
         $expectedResult = 'mysql:host=' . $server->getHost() . ';dbname=' . $server->getDatabaseName() . ';'
             . 'port=' . $server->getPort() . ';charset=' . $server->getCharset() . ';'
             . 'unix_socket=' . $unixSocket . ';';
-        $this->assertEquals($expectedResult, $this->getDSN($driver, $server, ['unix_socket' => $unixSocket]));
+        $this->assertSame($expectedResult, $this->getDSN($driver, $server, ['unix_socket' => $unixSocket]));
     }
 
     /**
@@ -41,7 +41,7 @@ class DriverTest extends \PHPUnit\Framework\TestCase
         $driver = new Driver();
         $expectedResult = 'mysql:host=' . $server->getHost() . ';dbname=' . $server->getDatabaseName() . ';'
             . 'port=' . $server->getPort() . ';charset=' . $server->getCharset() . ';';
-        $this->assertEquals($expectedResult, $this->getDSN($driver, $server));
+        $this->assertSame($expectedResult, $this->getDSN($driver, $server));
     }
 
     /**

--- a/src/Opulence/Databases/Tests/Adapters/Pdo/PostgreSql/DriverTest.php
+++ b/src/Opulence/Databases/Tests/Adapters/Pdo/PostgreSql/DriverTest.php
@@ -29,7 +29,7 @@ class DriverTest extends \PHPUnit\Framework\TestCase
         $expectedResult = 'pgsql:host=' . $server->getHost() . ';dbname=' . $server->getDatabaseName() . ';'
             . 'port=' . $server->getPort() . ";options='--client_encoding=" . $server->getCharset() . "';"
             . 'sslmode=' . $sslMode . ';';
-        $this->assertEquals($expectedResult, $this->getDSN($driver, $server, ['sslmode' => $sslMode]));
+        $this->assertSame($expectedResult, $this->getDSN($driver, $server, ['sslmode' => $sslMode]));
     }
 
     /**
@@ -41,7 +41,7 @@ class DriverTest extends \PHPUnit\Framework\TestCase
         $driver = new Driver();
         $expectedResult = 'pgsql:host=' . $server->getHost() . ';dbname=' . $server->getDatabaseName() . ';'
             . 'port=' . $server->getPort() . ";options='--client_encoding=" . $server->getCharset() . "';";
-        $this->assertEquals($expectedResult, $this->getDSN($driver, $server));
+        $this->assertSame($expectedResult, $this->getDSN($driver, $server));
     }
 
     /**

--- a/src/Opulence/Databases/Tests/ConnectionPools/Strategies/ServerSelection/RandomServerSelectionStrategyTest.php
+++ b/src/Opulence/Databases/Tests/ConnectionPools/Strategies/ServerSelection/RandomServerSelectionStrategyTest.php
@@ -46,7 +46,7 @@ class RandomServerSelectionStrategyTest extends \PHPUnit\Framework\TestCase
     {
         $server1 = $this->getServerMock();
         $server2 = $this->getServerMock();
-        $this->assertTrue(in_array($this->strategy->select([$server1, $server2]), [$server1, $server2]));
+        $this->assertContains($this->strategy->select([$server1, $server2]), [$server1, $server2]);
     }
 
     /**

--- a/src/Opulence/Databases/Tests/Providers/PostgreSqlProviderTest.php
+++ b/src/Opulence/Databases/Tests/Providers/PostgreSqlProviderTest.php
@@ -72,7 +72,7 @@ class PostgreSqlProviderTest extends \PHPUnit\Framework\TestCase
      */
     public function testConvertingToSqlBoolean()
     {
-        $this->assertEquals('t', $this->provider->convertToSqlBoolean(true));
-        $this->assertEquals('f', $this->provider->convertToSqlBoolean(false));
+        $this->assertSame('t', $this->provider->convertToSqlBoolean(true));
+        $this->assertSame('f', $this->provider->convertToSqlBoolean(false));
     }
 }

--- a/src/Opulence/Databases/Tests/Providers/ProviderTest.php
+++ b/src/Opulence/Databases/Tests/Providers/ProviderTest.php
@@ -50,7 +50,7 @@ class ProviderTest extends \PHPUnit\Framework\TestCase
      */
     public function testConvertingToSqlBoolean()
     {
-        $this->assertEquals(1, $this->provider->convertToSqlBoolean(true));
-        $this->assertEquals(0, $this->provider->convertToSqlBoolean(false));
+        $this->assertSame(1, $this->provider->convertToSqlBoolean(true));
+        $this->assertSame(0, $this->provider->convertToSqlBoolean(false));
     }
 }

--- a/src/Opulence/Databases/Tests/Providers/Types/TypeMapperTest.php
+++ b/src/Opulence/Databases/Tests/Providers/Types/TypeMapperTest.php
@@ -86,19 +86,19 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
         $phpDate = new DateTime('now');
         $sqlDate = $phpDate->format($this->provider->getDateFormat());
         // Compare the formatted string because testing sometimes leads to the type mapper's date to be one second later
-        $this->assertEquals(
+        $this->assertSame(
             $phpDate->format('Ymd'),
             $this->typeMapperWithNoProvider->fromSqlDate($sqlDate, $this->provider)->format('Ymd')
         );
         // Make sure the hour, minutes, and seconds are zeroed out
-        $this->assertEquals('000000',
+        $this->assertSame('000000',
             $this->typeMapperWithNoProvider->fromSqlDate($sqlDate, $this->provider)->format('His'));
-        $this->assertEquals(
+        $this->assertSame(
             $phpDate->format('Ymd'),
             $this->typeMapperWithProvider->fromSqlDate($sqlDate)->format('Ymd')
         );
         // Make sure the hour, minutes, and seconds are zeroed out
-        $this->assertEquals('000000', $this->typeMapperWithProvider->fromSqlDate($sqlDate)->format('His'));
+        $this->assertSame('000000', $this->typeMapperWithProvider->fromSqlDate($sqlDate)->format('His'));
     }
 
     /**
@@ -108,15 +108,15 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     {
         $phpTimeWithMicroseconds = new DateTime('now');
         $sqlTimeWithMicroseconds = $phpTimeWithMicroseconds->format('H:i:s.uP');
-        $this->assertEquals($phpTimeWithMicroseconds->getTimestamp(), $this->typeMapperWithNoProvider
+        $this->assertSame($phpTimeWithMicroseconds->getTimestamp(), $this->typeMapperWithNoProvider
             ->fromSqlTimestampWithTimeZone($sqlTimeWithMicroseconds, $this->provider)->getTimestamp());
-        $this->assertEquals($phpTimeWithMicroseconds->getTimestamp(), $this->typeMapperWithProvider
+        $this->assertSame($phpTimeWithMicroseconds->getTimestamp(), $this->typeMapperWithProvider
             ->fromSqlTimestampWithTimeZone($sqlTimeWithMicroseconds)->getTimestamp());
         $phpTime = new DateTime('now');
         $sqlTime = $phpTime->format($this->provider->getTimeWithTimeZoneFormat());
-        $this->assertEquals($phpTime->getTimestamp(),
+        $this->assertSame($phpTime->getTimestamp(),
             $this->typeMapperWithNoProvider->fromSqlTimeWithTimeZone($sqlTime, $this->provider)->getTimestamp());
-        $this->assertEquals($phpTime->getTimestamp(),
+        $this->assertSame($phpTime->getTimestamp(),
             $this->typeMapperWithProvider->fromSqlTimeWithTimeZone($sqlTime)->getTimestamp());
     }
 
@@ -134,12 +134,12 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
         $phpTime = new DateTime('now');
         $sqlTime = $phpTime->format($this->provider->getTimeWithoutTimeZoneFormat());
         // We do the flooring of the timestamp because, since PHP 7.1, new DateTime("now") contains microseconds
-        $this->assertEquals(
+        $this->assertSame(
             floor($phpTime->getTimestamp()),
             floor($this->typeMapperWithNoProvider->fromSqlTimeWithoutTimeZone($sqlTime,
                 $this->provider)->getTimestamp())
         );
-        $this->assertEquals(
+        $this->assertSame(
             floor($phpTime->getTimestamp()),
             floor($this->typeMapperWithProvider->fromSqlTimeWithoutTimeZone($sqlTime)->getTimestamp())
         );
@@ -152,18 +152,18 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     {
         $phpTimestampWithMicroseconds = new DateTime('now');
         $sqlTimestampWithMicroseconds = $phpTimestampWithMicroseconds->format('Y-m-d H:i:s.uP');
-        $this->assertEquals($phpTimestampWithMicroseconds->getTimestamp(), $this->typeMapperWithNoProvider
+        $this->assertSame($phpTimestampWithMicroseconds->getTimestamp(), $this->typeMapperWithNoProvider
             ->fromSqlTimestampWithTimeZone($sqlTimestampWithMicroseconds, $this->provider)->getTimestamp());
-        $this->assertEquals($phpTimestampWithMicroseconds->getTimestamp(), $this->typeMapperWithProvider
+        $this->assertSame($phpTimestampWithMicroseconds->getTimestamp(), $this->typeMapperWithProvider
             ->fromSqlTimestampWithTimeZone($sqlTimestampWithMicroseconds)->getTimestamp());
         $phpTimestamp = new DateTime('now');
         $sqlTimestamp = $phpTimestamp->format($this->provider->getTimestampWithTimeZoneFormat());
         // We do the flooring of the timestamp because, since PHP 7.1, new DateTime("now") contains microseconds
-        $this->assertEquals(
+        $this->assertSame(
             floor($phpTimestamp->getTimestamp()),
             floor($this->typeMapperWithNoProvider->fromSqlTimestampWithTimeZone($sqlTimestamp,
                 $this->provider)->getTimestamp()));
-        $this->assertEquals(
+        $this->assertSame(
             floor($phpTimestamp->getTimestamp()),
             floor($this->typeMapperWithProvider->fromSqlTimestampWithTimeZone($sqlTimestamp)->getTimestamp()));
     }
@@ -182,11 +182,11 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
         $phpTimestamp = new DateTime('now');
         $sqlTimestamp = $phpTimestamp->format($this->provider->getTimestampWithoutTimeZoneFormat());
         // We do the flooring of the timestamp because, since PHP 7.1, new DateTime("now") contains microseconds
-        $this->assertEquals(
+        $this->assertSame(
             floor($phpTimestamp->getTimestamp()),
             floor($this->typeMapperWithNoProvider
                 ->fromSqlTimestampWithoutTimeZone($sqlTimestamp, $this->provider)->getTimestamp()));
-        $this->assertEquals(
+        $this->assertSame(
             floor($phpTimestamp->getTimestamp()),
             floor($this->typeMapperWithProvider
                 ->fromSqlTimestampWithoutTimeZone($sqlTimestamp)->getTimestamp()));
@@ -268,8 +268,8 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
      */
     public function testConvertingToFalseSqlBoolean()
     {
-        $this->assertEquals(0, $this->typeMapperWithNoProvider->toSqlBoolean(false, $this->provider));
-        $this->assertEquals(0, $this->typeMapperWithProvider->toSqlBoolean(false));
+        $this->assertSame(0, $this->typeMapperWithNoProvider->toSqlBoolean(false, $this->provider));
+        $this->assertSame(0, $this->typeMapperWithProvider->toSqlBoolean(false));
     }
 
     /**
@@ -278,9 +278,9 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     public function testConvertingToSqlDate()
     {
         $date = new DateTime('now');
-        $this->assertEquals($date->format($this->provider->getDateFormat()),
+        $this->assertSame($date->format($this->provider->getDateFormat()),
             $this->typeMapperWithNoProvider->toSqlDate($date, $this->provider));
-        $this->assertEquals($date->format($this->provider->getDateFormat()),
+        $this->assertSame($date->format($this->provider->getDateFormat()),
             $this->typeMapperWithProvider->toSqlDate($date));
     }
 
@@ -306,9 +306,9 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     public function testConvertingToSqlTimeWithTimeZone()
     {
         $time = new DateTime('now');
-        $this->assertEquals($time->format($this->provider->getTimeWithTimeZoneFormat()),
+        $this->assertSame($time->format($this->provider->getTimeWithTimeZoneFormat()),
             $this->typeMapperWithNoProvider->toSqlTimeWithTimeZone($time, $this->provider));
-        $this->assertEquals($time->format($this->provider->getTimeWithTimeZoneFormat()),
+        $this->assertSame($time->format($this->provider->getTimeWithTimeZoneFormat()),
             $this->typeMapperWithProvider->toSqlTimeWithTimeZone($time));
     }
 
@@ -318,9 +318,9 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     public function testConvertingToSqlTimeWithoutTimeZone()
     {
         $time = new DateTime('now');
-        $this->assertEquals($time->format($this->provider->getTimeWithoutTimeZoneFormat()),
+        $this->assertSame($time->format($this->provider->getTimeWithoutTimeZoneFormat()),
             $this->typeMapperWithNoProvider->toSqlTimeWithoutTimeZone($time, $this->provider));
-        $this->assertEquals($time->format($this->provider->getTimeWithoutTimeZoneFormat()),
+        $this->assertSame($time->format($this->provider->getTimeWithoutTimeZoneFormat()),
             $this->typeMapperWithProvider->toSqlTimeWithoutTimeZone($time));
     }
 
@@ -330,9 +330,9 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     public function testConvertingToSqlTimestampWithTimeZone()
     {
         $timestamp = new DateTime('now');
-        $this->assertEquals($timestamp->format($this->provider->getTimestampWithTimeZoneFormat()),
+        $this->assertSame($timestamp->format($this->provider->getTimestampWithTimeZoneFormat()),
             $this->typeMapperWithNoProvider->toSqlTimestampWithTimeZone($timestamp, $this->provider));
-        $this->assertEquals($timestamp->format($this->provider->getTimestampWithTimeZoneFormat()),
+        $this->assertSame($timestamp->format($this->provider->getTimestampWithTimeZoneFormat()),
             $this->typeMapperWithProvider->toSqlTimestampWithTimeZone($timestamp));
     }
 
@@ -342,9 +342,9 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     public function testConvertingToSqlTimestampWithoutTimeZone()
     {
         $timestamp = new DateTime('now');
-        $this->assertEquals($timestamp->format($this->provider->getTimestampWithoutTimeZoneFormat()),
+        $this->assertSame($timestamp->format($this->provider->getTimestampWithoutTimeZoneFormat()),
             $this->typeMapperWithNoProvider->toSqlTimestampWithoutTimeZone($timestamp, $this->provider));
-        $this->assertEquals($timestamp->format($this->provider->getTimestampWithoutTimeZoneFormat()),
+        $this->assertSame($timestamp->format($this->provider->getTimestampWithoutTimeZoneFormat()),
             $this->typeMapperWithProvider->toSqlTimestampWithoutTimeZone($timestamp));
     }
 
@@ -353,8 +353,8 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
      */
     public function testConvertingToTrueSqlBoolean()
     {
-        $this->assertEquals(1, $this->typeMapperWithNoProvider->toSqlBoolean(true, $this->provider));
-        $this->assertEquals(1, $this->typeMapperWithProvider->toSqlBoolean(true));
+        $this->assertSame(1, $this->typeMapperWithNoProvider->toSqlBoolean(true, $this->provider));
+        $this->assertSame(1, $this->typeMapperWithProvider->toSqlBoolean(true));
     }
 
     /**

--- a/src/Opulence/Databases/Tests/ServerTest.php
+++ b/src/Opulence/Databases/Tests/ServerTest.php
@@ -25,7 +25,7 @@ class ServerTest extends \PHPUnit\Framework\TestCase
         $charset = 'foo';
         $server = new Server();
         $server->setCharset($charset);
-        $this->assertEquals($charset, $server->getCharset());
+        $this->assertSame($charset, $server->getCharset());
     }
 
     /**
@@ -41,12 +41,12 @@ class ServerTest extends \PHPUnit\Framework\TestCase
             123,
             'charset'
         );
-        $this->assertEquals('127.0.0.1', $server->getHost());
-        $this->assertEquals('username', $server->getUsername());
-        $this->assertEquals('password', $server->getPassword());
-        $this->assertEquals('dbname', $server->getDatabaseName());
-        $this->assertEquals(123, $server->getPort());
-        $this->assertEquals('charset', $server->getCharset());
+        $this->assertSame('127.0.0.1', $server->getHost());
+        $this->assertSame('username', $server->getUsername());
+        $this->assertSame('password', $server->getPassword());
+        $this->assertSame('dbname', $server->getDatabaseName());
+        $this->assertSame(123, $server->getPort());
+        $this->assertSame('charset', $server->getCharset());
     }
 
     /**
@@ -57,7 +57,7 @@ class ServerTest extends \PHPUnit\Framework\TestCase
         $databaseName = 'dbname';
         $server = new Server();
         $server->setDatabaseName($databaseName);
-        $this->assertEquals($databaseName, $server->getDatabaseName());
+        $this->assertSame($databaseName, $server->getDatabaseName());
     }
 
     /**
@@ -67,7 +67,7 @@ class ServerTest extends \PHPUnit\Framework\TestCase
     {
         $server = new Server();
         $server->setHost('127.0.0.1');
-        $this->assertEquals('127.0.0.1', $server->getHost());
+        $this->assertSame('127.0.0.1', $server->getHost());
     }
 
     /**
@@ -78,7 +78,7 @@ class ServerTest extends \PHPUnit\Framework\TestCase
         $password = 'bar';
         $server = new Server();
         $server->setPassword($password);
-        $this->assertEquals($password, $server->getPassword());
+        $this->assertSame($password, $server->getPassword());
     }
 
     /**
@@ -88,7 +88,7 @@ class ServerTest extends \PHPUnit\Framework\TestCase
     {
         $server = new Server();
         $server->setPort(80);
-        $this->assertEquals(80, $server->getPort());
+        $this->assertSame(80, $server->getPort());
     }
 
     /**
@@ -99,6 +99,6 @@ class ServerTest extends \PHPUnit\Framework\TestCase
         $name = 'foo';
         $server = new Server();
         $server->setUsername($name);
-        $this->assertEquals($name, $server->getUsername());
+        $this->assertSame($name, $server->getUsername());
     }
 }

--- a/src/Opulence/Debug/Tests/Errors/Handlers/ErrorHandlerTest.php
+++ b/src/Opulence/Debug/Tests/Errors/Handlers/ErrorHandlerTest.php
@@ -79,11 +79,11 @@ class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
             $handler->handle(1, 'foo', 'bar', 2, ['baz']);
         } catch (ErrorException $ex) {
             $exceptionCaught = true;
-            $this->assertEquals(1, $ex->getSeverity());
-            $this->assertEquals('foo', $ex->getMessage());
-            $this->assertEquals('bar', $ex->getFile());
-            $this->assertEquals(2, $ex->getLine());
-            $this->assertEquals(0, $ex->getCode());
+            $this->assertSame(1, $ex->getSeverity());
+            $this->assertSame('foo', $ex->getMessage());
+            $this->assertSame('bar', $ex->getFile());
+            $this->assertSame(2, $ex->getLine());
+            $this->assertSame(0, $ex->getCode());
         }
 
         $this->assertTrue($exceptionCaught);

--- a/src/Opulence/Environments/Tests/EnvironmentTest.php
+++ b/src/Opulence/Environments/Tests/EnvironmentTest.php
@@ -22,7 +22,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingNonExistentVariable()
     {
-        $this->assertEquals('bar', Environment::getVar('foo', 'bar'));
+        $this->assertSame('bar', Environment::getVar('foo', 'bar'));
     }
 
     /**
@@ -31,9 +31,9 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
     public function testGettingVariable()
     {
         Environment::setVar('baz', 'blah');
-        $this->assertEquals('blah', getenv('baz'));
-        $this->assertEquals('blah', $_ENV['baz']);
-        $this->assertEquals('blah', $_SERVER['baz']);
+        $this->assertSame('blah', getenv('baz'));
+        $this->assertSame('blah', $_ENV['baz']);
+        $this->assertSame('blah', $_SERVER['baz']);
     }
 
     /**
@@ -50,9 +50,9 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
     public function testSettingVariable()
     {
         Environment::setVar('foo', 'bar');
-        $this->assertEquals('bar', getenv('foo'));
-        $this->assertEquals('bar', $_ENV['foo']);
-        $this->assertEquals('bar', $_SERVER['foo']);
+        $this->assertSame('bar', getenv('foo'));
+        $this->assertSame('bar', $_ENV['foo']);
+        $this->assertSame('bar', $_SERVER['foo']);
     }
 
     /**
@@ -61,7 +61,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
     public function testSettingVariableInEnvironmentGlobalArray()
     {
         $_ENV['bar'] = 'baz';
-        $this->assertEquals('baz', Environment::getVar('bar'));
+        $this->assertSame('baz', Environment::getVar('bar'));
     }
 
     /**
@@ -70,7 +70,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
     public function testSettingVariableInPutenv()
     {
         putenv('bar=baz');
-        $this->assertEquals('baz', Environment::getVar('bar'));
+        $this->assertSame('baz', Environment::getVar('bar'));
     }
 
     /**
@@ -79,7 +79,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
     public function testSettingVariableInServerGlobalArray()
     {
         $_SERVER['bar'] = 'baz';
-        $this->assertEquals('baz', Environment::getVar('bar'));
+        $this->assertSame('baz', Environment::getVar('bar'));
     }
 
     /**
@@ -89,7 +89,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
     {
         Environment::setVar('foo', 'bar');
         Environment::setVar('foo', 'baz');
-        $this->assertEquals('bar', Environment::getVar('foo'));
-        $this->assertEquals('bar', getenv('foo'));
+        $this->assertSame('bar', Environment::getVar('foo'));
+        $this->assertSame('bar', getenv('foo'));
     }
 }

--- a/src/Opulence/Framework/Tests/Composer/ComposerTest.php
+++ b/src/Opulence/Framework/Tests/Composer/ComposerTest.php
@@ -71,9 +71,9 @@ class ComposerTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingFullyQualifiedClassName()
     {
-        $this->assertEquals('Opulence\\Bar', $this->composer->getFullyQualifiedClassName('Bar', 'Opulence'));
-        $this->assertEquals('Opulence\\Foo\\Bar', $this->composer->getFullyQualifiedClassName('Bar', 'Opulence\\Foo'));
-        $this->assertEquals('Opulence\\Bar', $this->composer->getFullyQualifiedClassName('Bar', 'Opulence\\'));
+        $this->assertSame('Opulence\\Bar', $this->composer->getFullyQualifiedClassName('Bar', 'Opulence'));
+        $this->assertSame('Opulence\\Foo\\Bar', $this->composer->getFullyQualifiedClassName('Bar', 'Opulence\\Foo'));
+        $this->assertSame('Opulence\\Bar', $this->composer->getFullyQualifiedClassName('Bar', 'Opulence\\'));
     }
 
     /**
@@ -81,7 +81,7 @@ class ComposerTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingFullyQualifiedClassNameOfAFullyQualifiedClass()
     {
-        $this->assertEquals('Opulence\\Foo\\Bar',
+        $this->assertSame('Opulence\\Foo\\Bar',
             $this->composer->getFullyQualifiedClassName('Opulence\\Foo\\Bar', 'Opulence'));
     }
 
@@ -136,7 +136,7 @@ class ComposerTest extends \PHPUnit\Framework\TestCase
     public function testGettingPathFromClass()
     {
         $class = 'Opulence\\Foo\\Bar';
-        $this->assertEquals(
+        $this->assertSame(
             $this->psr4RootPath . DIRECTORY_SEPARATOR . 'Opulence' . DIRECTORY_SEPARATOR . 'Foo' . DIRECTORY_SEPARATOR . 'Bar.php',
             $this->composer->getClassPath($class)
         );
@@ -148,7 +148,7 @@ class ComposerTest extends \PHPUnit\Framework\TestCase
     public function testGettingPathFromClassInRootNamespace()
     {
         $class = 'Opulence\\Bar';
-        $this->assertEquals(
+        $this->assertSame(
             $this->psr4RootPath . DIRECTORY_SEPARATOR . 'Opulence' . DIRECTORY_SEPARATOR . 'Bar.php',
             $this->composer->getClassPath($class)
         );
@@ -178,7 +178,7 @@ class ComposerTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingRootNamespace()
     {
-        $this->assertEquals('Opulence', $this->composer->getRootNamespace());
+        $this->assertSame('Opulence', $this->composer->getRootNamespace());
     }
 
     /**
@@ -212,7 +212,7 @@ class ComposerTest extends \PHPUnit\Framework\TestCase
             $this->rootPath,
             $this->psr4RootPath
         );
-        $this->assertEquals('Opulence', $composer->getRootNamespace());
+        $this->assertSame('Opulence', $composer->getRootNamespace());
     }
 
     /**
@@ -220,6 +220,6 @@ class ComposerTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingSingleProperty()
     {
-        $this->assertEquals('__name__', $this->composer->get('name'));
+        $this->assertSame('__name__', $this->composer->get('name'));
     }
 }

--- a/src/Opulence/Framework/Tests/Composer/ExecutableTest.php
+++ b/src/Opulence/Framework/Tests/Composer/ExecutableTest.php
@@ -36,8 +36,8 @@ class ExecutableTest extends \PHPUnit\Framework\TestCase
      */
     public function testDumpAutoload()
     {
-        $this->assertEquals('composer dump-autoload ', $this->executableWithoutPHAR->dumpAutoload());
-        $this->assertEquals(
+        $this->assertSame('composer dump-autoload ', $this->executableWithoutPHAR->dumpAutoload());
+        $this->assertSame(
             '"' . PHP_BINARY . '" composer.phar dump-autoload ',
             $this->executableWithPHAR->dumpAutoload()
         );
@@ -48,8 +48,8 @@ class ExecutableTest extends \PHPUnit\Framework\TestCase
      */
     public function testDumpAutoloadWithOptions()
     {
-        $this->assertEquals('composer dump-autoload -o', $this->executableWithoutPHAR->dumpAutoload('-o'));
-        $this->assertEquals(
+        $this->assertSame('composer dump-autoload -o', $this->executableWithoutPHAR->dumpAutoload('-o'));
+        $this->assertSame(
             '"' . PHP_BINARY . '" composer.phar dump-autoload -o',
             $this->executableWithPHAR->dumpAutoload('-o')
         );
@@ -60,8 +60,8 @@ class ExecutableTest extends \PHPUnit\Framework\TestCase
      */
     public function testUpdate()
     {
-        $this->assertEquals('composer update ', $this->executableWithoutPHAR->update());
-        $this->assertEquals(
+        $this->assertSame('composer update ', $this->executableWithoutPHAR->update());
+        $this->assertSame(
             '"' . PHP_BINARY . '" composer.phar update ',
             $this->executableWithPHAR->update()
         );
@@ -72,8 +72,8 @@ class ExecutableTest extends \PHPUnit\Framework\TestCase
      */
     public function testUpdateWithOptions()
     {
-        $this->assertEquals('composer update --prefer-dist', $this->executableWithoutPHAR->update('--prefer-dist'));
-        $this->assertEquals(
+        $this->assertSame('composer update --prefer-dist', $this->executableWithoutPHAR->update('--prefer-dist'));
+        $this->assertSame(
             '"' . PHP_BINARY . '" composer.phar update --prefer-dist',
             $this->executableWithPHAR->update('--prefer-dist')
         );

--- a/src/Opulence/Framework/Tests/Configuration/ConfigTest.php
+++ b/src/Opulence/Framework/Tests/Configuration/ConfigTest.php
@@ -23,7 +23,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     public function testGettingNonExistentValue()
     {
         $this->assertNull(Config::get('foo', 'bar'));
-        $this->assertEquals('baz', Config::get('foo', 'bar', 'baz'));
+        $this->assertSame('baz', Config::get('foo', 'bar', 'baz'));
         $this->assertFalse(Config::has('foo', 'bar'));
     }
 
@@ -33,10 +33,10 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     public function testSettingCategory()
     {
         Config::setCategory('foo', ['bar' => 'baz']);
-        $this->assertEquals('baz', Config::get('foo', 'bar'));
+        $this->assertSame('baz', Config::get('foo', 'bar'));
         $this->assertTrue(Config::has('foo', 'bar'));
         Config::setCategory('foo', ['dave' => 'young']);
-        $this->assertEquals('young', Config::get('foo', 'dave'));
+        $this->assertSame('young', Config::get('foo', 'dave'));
         $this->assertTrue(Config::has('foo', 'dave'));
     }
 
@@ -46,10 +46,10 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     public function testSettingSingleSetting()
     {
         Config::set('foo', 'bar', 'baz');
-        $this->assertEquals('baz', Config::get('foo', 'bar'));
+        $this->assertSame('baz', Config::get('foo', 'bar'));
         $this->assertTrue(Config::has('foo', 'bar'));
         Config::set('foo', 'bar', 'blah');
-        $this->assertEquals('blah', Config::get('foo', 'bar'));
+        $this->assertSame('blah', Config::get('foo', 'bar'));
         $this->assertTrue(Config::has('foo', 'bar'));
     }
 }

--- a/src/Opulence/Framework/Tests/Debug/Exceptions/Handlers/Http/ExceptionRendererTest.php
+++ b/src/Opulence/Framework/Tests/Debug/Exceptions/Handlers/Http/ExceptionRendererTest.php
@@ -85,8 +85,8 @@ class ExceptionRendererTest extends \PHPUnit\Framework\TestCase
             ->willReturn('bar');
         $this->renderer->render($ex);
         $this->assertInstanceOf(Response::class, $this->renderer->getResponse());
-        $this->assertEquals('bar', $this->renderer->getResponse()->getContent());
-        $this->assertEquals(404, $this->renderer->getResponse()->getStatusCode());
+        $this->assertSame('bar', $this->renderer->getResponse()->getContent());
+        $this->assertSame(404, $this->renderer->getResponse()->getStatusCode());
     }
 
     /**
@@ -98,8 +98,8 @@ class ExceptionRendererTest extends \PHPUnit\Framework\TestCase
         $this->viewFactory->expects($this->never())
             ->method('hasView');
         $this->renderer->render($ex);
-        $this->assertEquals($ex->getMessage(), $this->renderer->getResponse()->getContent());
-        $this->assertEquals(404, $this->renderer->getResponse()->getStatusCode());
+        $this->assertSame($ex->getMessage(), $this->renderer->getResponse()->getContent());
+        $this->assertSame(404, $this->renderer->getResponse()->getStatusCode());
     }
 
     /**
@@ -114,8 +114,8 @@ class ExceptionRendererTest extends \PHPUnit\Framework\TestCase
             ->with('errors/html/404')
             ->willReturn(false);
         $this->renderer->render($ex);
-        $this->assertEquals($ex->getMessage(), $this->renderer->getResponse()->getContent());
-        $this->assertEquals(404, $this->renderer->getResponse()->getStatusCode());
+        $this->assertSame($ex->getMessage(), $this->renderer->getResponse()->getContent());
+        $this->assertSame(404, $this->renderer->getResponse()->getStatusCode());
     }
 
     /**
@@ -131,8 +131,8 @@ class ExceptionRendererTest extends \PHPUnit\Framework\TestCase
             ->with('errors/html/404')
             ->willReturn(false);
         $this->renderer->render($ex);
-        $this->assertEquals('Something went wrong', $this->renderer->getResponse()->getContent());
-        $this->assertEquals(404, $this->renderer->getResponse()->getStatusCode());
+        $this->assertSame('Something went wrong', $this->renderer->getResponse()->getContent());
+        $this->assertSame(404, $this->renderer->getResponse()->getStatusCode());
     }
 
     /**
@@ -168,7 +168,7 @@ class ExceptionRendererTest extends \PHPUnit\Framework\TestCase
             ->willReturn('bar');
         $this->renderer->render($ex);
         $this->assertInstanceOf(JsonResponse::class, $this->renderer->getResponse());
-        $this->assertEquals(500, $this->renderer->getResponse()->getStatusCode());
+        $this->assertSame(500, $this->renderer->getResponse()->getStatusCode());
         $this->assertEquals(json_encode(['foo' => 'bar']), $this->renderer->getResponse()->getContent());
     }
 
@@ -193,8 +193,8 @@ class ExceptionRendererTest extends \PHPUnit\Framework\TestCase
             ->with($view)
             ->willReturn('bar');
         $this->renderer->render($ex);
-        $this->assertEquals('bar', $this->renderer->getResponse()->getContent());
-        $this->assertEquals(500, $this->renderer->getResponse()->getStatusCode());
+        $this->assertSame('bar', $this->renderer->getResponse()->getContent());
+        $this->assertSame(500, $this->renderer->getResponse()->getStatusCode());
     }
 
     /**
@@ -209,8 +209,8 @@ class ExceptionRendererTest extends \PHPUnit\Framework\TestCase
             ->with('errors/html/500')
             ->willReturn(false);
         $this->renderer->render($ex);
-        $this->assertEquals($ex->getMessage(), $this->renderer->getResponse()->getContent());
-        $this->assertEquals(500, $this->renderer->getResponse()->getStatusCode());
+        $this->assertSame($ex->getMessage(), $this->renderer->getResponse()->getContent());
+        $this->assertSame(500, $this->renderer->getResponse()->getStatusCode());
     }
 
     /**
@@ -226,8 +226,8 @@ class ExceptionRendererTest extends \PHPUnit\Framework\TestCase
             ->with('errors/html/500')
             ->willReturn(false);
         $this->renderer->render($ex);
-        $this->assertEquals('Something went wrong', $this->renderer->getResponse()->getContent());
-        $this->assertEquals(500, $this->renderer->getResponse()->getStatusCode());
+        $this->assertSame('Something went wrong', $this->renderer->getResponse()->getContent());
+        $this->assertSame(500, $this->renderer->getResponse()->getStatusCode());
     }
 
     /**

--- a/src/Opulence/Framework/Tests/Http/KernelTest.php
+++ b/src/Opulence/Framework/Tests/Http/KernelTest.php
@@ -135,7 +135,7 @@ class KernelTest extends \PHPUnit\Framework\TestCase
         $request = Request::createFromGlobals();
         $response = $kernel->handle($request);
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals(ResponseHeaders::HTTP_OK, $response->getStatusCode());
+        $this->assertSame(ResponseHeaders::HTTP_OK, $response->getStatusCode());
     }
 
     /**
@@ -147,7 +147,7 @@ class KernelTest extends \PHPUnit\Framework\TestCase
         $kernel->addMiddleware(HeaderSetter::class);
         $request = Request::createFromGlobals();
         $response = $kernel->handle($request);
-        $this->assertEquals('bar', $response->getHeaders()->get('foo'));
+        $this->assertSame('bar', $response->getHeaders()->get('foo'));
     }
 
     /**
@@ -159,7 +159,7 @@ class KernelTest extends \PHPUnit\Framework\TestCase
         $kernel->addMiddleware(ParameterizedMiddleware::withParameters(['foo' => 'bar']));
         $request = Request::createFromGlobals();
         $response = $kernel->handle($request);
-        $this->assertEquals('middleware', $response->getHeaders()->get('parameterized'));
+        $this->assertSame('middleware', $response->getHeaders()->get('parameterized'));
     }
 
     /**

--- a/src/Opulence/Framework/Tests/Views/Caching/GenericCacheTest.php
+++ b/src/Opulence/Framework/Tests/Views/Caching/GenericCacheTest.php
@@ -49,7 +49,7 @@ class GenericCacheTest extends \PHPUnit\Framework\TestCase
             ->method('has')
             ->with($this->getKey($this->view))
             ->willReturn(true);
-        $this->assertEquals('compiled', $this->cache->get($this->view));
+        $this->assertSame('compiled', $this->cache->get($this->view));
         $this->assertTrue($this->cache->has($this->view));
     }
 
@@ -89,7 +89,7 @@ class GenericCacheTest extends \PHPUnit\Framework\TestCase
             ->method('get')
             ->with($this->getKey($this->view))
             ->willReturn('compiled');
-        $this->assertEquals('compiled', $this->cache->get($this->view));
+        $this->assertSame('compiled', $this->cache->get($this->view));
     }
 
     /**

--- a/src/Opulence/Http/Tests/CollectionTest.php
+++ b/src/Opulence/Http/Tests/CollectionTest.php
@@ -34,7 +34,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     public function testAdding()
     {
         $this->parameters->add('foo', 'bar');
-        $this->assertEquals('bar', $this->parameters->get('foo'));
+        $this->assertSame('bar', $this->parameters->get('foo'));
     }
 
     /**
@@ -52,9 +52,9 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     public function testCount()
     {
         $this->parameters->add('foo', 'bar');
-        $this->assertEquals(1, $this->parameters->count());
+        $this->assertSame(1, $this->parameters->count());
         $this->parameters->add('bar', 'foo');
-        $this->assertEquals(2, $this->parameters->count());
+        $this->assertSame(2, $this->parameters->count());
     }
 
     /**
@@ -73,7 +73,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     public function testGetting()
     {
         $this->parameters->add('foo', 'bar');
-        $this->assertEquals('bar', $this->parameters->get('foo'));
+        $this->assertSame('bar', $this->parameters->get('foo'));
     }
 
     /**
@@ -81,7 +81,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingAbsentVariableWithDefault()
     {
-        $this->assertEquals('blah', $this->parameters->get('does not exist', 'blah'));
+        $this->assertSame('blah', $this->parameters->get('does not exist', 'blah'));
     }
 
     /**
@@ -111,7 +111,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     public function testGettingAsArray()
     {
         $this->parameters->add('foo', 'bar');
-        $this->assertEquals('bar', $this->parameters['foo']);
+        $this->assertSame('bar', $this->parameters['foo']);
     }
 
     /**
@@ -150,7 +150,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     public function testSetting()
     {
         $this->parameters->set('foo', 'bar');
-        $this->assertEquals('bar', $this->parameters->get('foo'));
+        $this->assertSame('bar', $this->parameters->get('foo'));
     }
 
     /**
@@ -159,7 +159,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     public function testSettingItem()
     {
         $this->parameters['foo'] = 'bar';
-        $this->assertEquals('bar', $this->parameters['foo']);
+        $this->assertSame('bar', $this->parameters['foo']);
     }
 
     /**

--- a/src/Opulence/Http/Tests/HeadersTest.php
+++ b/src/Opulence/Http/Tests/HeadersTest.php
@@ -34,7 +34,7 @@ class HeadersTest extends \PHPUnit\Framework\TestCase
     public function testAddedNamesAreNormalized()
     {
         $this->headers->add('FOO', 'fooval');
-        $this->assertEquals('fooval', $this->headers->get('foo'));
+        $this->assertSame('fooval', $this->headers->get('foo'));
         $this->assertTrue($this->headers->has('foo'));
     }
 
@@ -44,7 +44,7 @@ class HeadersTest extends \PHPUnit\Framework\TestCase
     public function testAddingStringValue()
     {
         $this->headers->add('foo', 'bar');
-        $this->assertEquals('bar', $this->headers->get('foo'));
+        $this->assertSame('bar', $this->headers->get('foo'));
     }
 
     /**
@@ -52,7 +52,7 @@ class HeadersTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingAllValuesWhenKeyDoesNotExist()
     {
-        $this->assertEquals('foo', $this->headers->get('THIS_DOES_NOT_EXIST', 'foo', false));
+        $this->assertSame('foo', $this->headers->get('THIS_DOES_NOT_EXIST', 'foo', false));
     }
 
     /**
@@ -61,7 +61,7 @@ class HeadersTest extends \PHPUnit\Framework\TestCase
     public function testGettingFirstValue()
     {
         $this->headers->set('FOO', 'bar');
-        $this->assertEquals('bar', $this->headers->get('FOO', null, true));
+        $this->assertSame('bar', $this->headers->get('FOO', null, true));
     }
 
     /**
@@ -69,7 +69,7 @@ class HeadersTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingFirstValueWhenKeyDoesNotExist()
     {
-        $this->assertEquals('foo', $this->headers->get('THIS_DOES_NOT_EXIST', 'foo', true));
+        $this->assertSame('foo', $this->headers->get('THIS_DOES_NOT_EXIST', 'foo', true));
     }
 
     /**
@@ -91,10 +91,10 @@ class HeadersTest extends \PHPUnit\Framework\TestCase
         $headers->add('BAR', 'barval');
         $headers->add('BAZ', 'bazval');
         $headers->add('BLAH', 'blahval');
-        $this->assertEquals('fooval', $headers->get('foo'));
-        $this->assertEquals('barval', $headers->get('bar'));
-        $this->assertEquals('bazval', $headers->get('baz'));
-        $this->assertEquals('blahval', $headers->get('blah'));
+        $this->assertSame('fooval', $headers->get('foo'));
+        $this->assertSame('barval', $headers->get('bar'));
+        $this->assertSame('bazval', $headers->get('baz'));
+        $this->assertSame('blahval', $headers->get('blah'));
         $this->assertTrue($headers->has('foo'));
         $this->assertTrue($headers->has('bar'));
         $this->assertTrue($headers->has('baz'));
@@ -112,7 +112,7 @@ class HeadersTest extends \PHPUnit\Framework\TestCase
     public function testSetNamesAreNormalized()
     {
         $this->headers->set('FOO', 'fooval');
-        $this->assertEquals('fooval', $this->headers->get('foo'));
+        $this->assertSame('fooval', $this->headers->get('foo'));
         $this->assertTrue($this->headers->has('foo'));
     }
 }

--- a/src/Opulence/Http/Tests/HttpExceptionTest.php
+++ b/src/Opulence/Http/Tests/HttpExceptionTest.php
@@ -43,7 +43,7 @@ class HttpExceptionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingCode()
     {
-        $this->assertEquals(4, $this->exception->getCode());
+        $this->assertSame(4, $this->exception->getCode());
     }
 
     /**
@@ -59,7 +59,7 @@ class HttpExceptionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingMessage()
     {
-        $this->assertEquals('foo', $this->exception->getMessage());
+        $this->assertSame('foo', $this->exception->getMessage());
     }
 
     /**
@@ -75,6 +75,6 @@ class HttpExceptionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingStatusCode()
     {
-        $this->assertEquals(404, $this->exception->getStatusCode());
+        $this->assertSame(404, $this->exception->getStatusCode());
     }
 }

--- a/src/Opulence/Http/Tests/Requests/FilesTest.php
+++ b/src/Opulence/Http/Tests/Requests/FilesTest.php
@@ -34,11 +34,11 @@ class FilesTest extends \PHPUnit\Framework\TestCase
         /** @var UploadedFile $file */
         $file = $files->get('foo');
         $this->assertInstanceOf(UploadedFile::class, $file);
-        $this->assertEquals('/path', $file->getPath());
-        $this->assertEquals('foo.txt', $file->getTempFilename());
-        $this->assertEquals(100, $file->getTempSize());
-        $this->assertEquals('text/plain', $file->getTempMimeType());
-        $this->assertEquals(UPLOAD_ERR_EXTENSION, $file->getError());
+        $this->assertSame('/path', $file->getPath());
+        $this->assertSame('foo.txt', $file->getTempFilename());
+        $this->assertSame(100, $file->getTempSize());
+        $this->assertSame('text/plain', $file->getTempMimeType());
+        $this->assertSame(UPLOAD_ERR_EXTENSION, $file->getError());
     }
 
     /**
@@ -58,10 +58,10 @@ class FilesTest extends \PHPUnit\Framework\TestCase
         /** @var UploadedFile $file */
         $file = $files->get('foo');
         $this->assertInstanceOf(UploadedFile::class, $file);
-        $this->assertEquals('/path', $file->getPath());
-        $this->assertEquals('foo.txt', $file->getTempFilename());
-        $this->assertEquals(100, $file->getTempSize());
-        $this->assertEquals('text/plain', $file->getTempMimeType());
-        $this->assertEquals(UPLOAD_ERR_EXTENSION, $file->getError());
+        $this->assertSame('/path', $file->getPath());
+        $this->assertSame('foo.txt', $file->getTempFilename());
+        $this->assertSame(100, $file->getTempSize());
+        $this->assertSame('text/plain', $file->getTempMimeType());
+        $this->assertSame(UPLOAD_ERR_EXTENSION, $file->getError());
     }
 }

--- a/src/Opulence/Http/Tests/Requests/RequestHeadersTest.php
+++ b/src/Opulence/Http/Tests/Requests/RequestHeadersTest.php
@@ -48,7 +48,7 @@ class RequestHeadersTest extends \PHPUnit\Framework\TestCase
     public function testAddedNamesAreNormalized()
     {
         $this->headers->add('HTTP_FOO', 'fooval');
-        $this->assertEquals('fooval', $this->headers->get('foo'));
+        $this->assertSame('fooval', $this->headers->get('foo'));
         $this->assertTrue($this->headers->has('foo'));
     }
 
@@ -86,7 +86,7 @@ class RequestHeadersTest extends \PHPUnit\Framework\TestCase
     public function testSetNamesAreNormalized()
     {
         $this->headers->set('HTTP_FOO', 'fooval');
-        $this->assertEquals('fooval', $this->headers->get('foo'));
+        $this->assertSame('fooval', $this->headers->get('foo'));
         $this->assertTrue($this->headers->has('foo'));
     }
 

--- a/src/Opulence/Http/Tests/Requests/RequestTest.php
+++ b/src/Opulence/Http/Tests/Requests/RequestTest.php
@@ -74,7 +74,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'PUT';
         $request = Request::createFromGlobals();
-        $this->assertEquals('PUT', $request->getMethod());
+        $this->assertSame('PUT', $request->getMethod());
     }
 
     /**
@@ -85,16 +85,16 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';
         $_SERVER['HTTP_CONTENT_LENGTH'] = 24;
         $request = Request::createFromGlobals();
-        $this->assertEquals('application/json', $request->getHeaders()->get('CONTENT_TYPE'));
-        $this->assertEquals(24, $request->getHeaders()->get('CONTENT_LENGTH'));
+        $this->assertSame('application/json', $request->getHeaders()->get('CONTENT_TYPE'));
+        $this->assertSame(24, $request->getHeaders()->get('CONTENT_LENGTH'));
 
         // Try again by specifying server array
         $server = [];
         $server['HTTP_CONTENT_TYPE'] = 'application/json';
         $server['HTTP_CONTENT_LENGTH'] = 24;
         $request = Request::createFromGlobals(null, null, null, $server);
-        $this->assertEquals('application/json', $request->getHeaders()->get('CONTENT_TYPE'));
-        $this->assertEquals(24, $request->getHeaders()->get('CONTENT_LENGTH'));
+        $this->assertSame('application/json', $request->getHeaders()->get('CONTENT_TYPE'));
+        $this->assertSame(24, $request->getHeaders()->get('CONTENT_LENGTH'));
     }
 
     /**
@@ -193,7 +193,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         Request::setTrustedHeaderName(RequestHeaders::CLIENT_IP, 'HTTP_CLIENT_IP');
         $_SERVER['HTTP_CLIENT_IP'] = '192.168.1.1';
         $request = Request::createFromGlobals();
-        $this->assertEquals('192.168.1.1', $request->getClientIPAddress());
+        $this->assertSame('192.168.1.1', $request->getClientIPAddress());
     }
 
     /**
@@ -206,7 +206,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         Request::setTrustedProxies('192.168.1.1');
         Request::setTrustedHeaderName(RequestHeaders::CLIENT_PORT, 'X-Forwarded-Port');
         $request = Request::createFromGlobals();
-        $this->assertEquals(8080, $request->getPort());
+        $this->assertSame(8080, $request->getPort());
     }
 
     /**
@@ -248,7 +248,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         Request::setTrustedProxies('192.168.1.1');
         Request::setTrustedHeaderName(RequestHeaders::CLIENT_PROTO, 'X-Forwarded-Proto');
         $request = Request::createFromGlobals();
-        $this->assertEquals(443, $request->getPort());
+        $this->assertSame(443, $request->getPort());
     }
 
     /**
@@ -276,11 +276,11 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testContentTypeSetForUnsupportedMethods()
     {
         $patchRequest = Request::createFromUrl('/url', 'PATCH');
-        $this->assertEquals('application/x-www-form-urlencoded', $patchRequest->getServer()->get('CONTENT_TYPE'));
+        $this->assertSame('application/x-www-form-urlencoded', $patchRequest->getServer()->get('CONTENT_TYPE'));
         $putRequest = Request::createFromUrl('/url', 'PUT');
-        $this->assertEquals('application/x-www-form-urlencoded', $putRequest->getServer()->get('CONTENT_TYPE'));
+        $this->assertSame('application/x-www-form-urlencoded', $putRequest->getServer()->get('CONTENT_TYPE'));
         $deleteRequest = Request::createFromUrl('/url', 'DELETE');
-        $this->assertEquals('application/x-www-form-urlencoded', $deleteRequest->getServer()->get('CONTENT_TYPE'));
+        $this->assertSame('application/x-www-form-urlencoded', $deleteRequest->getServer()->get('CONTENT_TYPE'));
     }
 
     /**
@@ -381,7 +381,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testCustomDefaultIsReturnedWhenNoInputFound()
     {
         $request = Request::createFromGlobals();
-        $this->assertEquals('bar', $request->getInput('foo', 'bar'));
+        $this->assertSame('bar', $request->getInput('foo', 'bar'));
     }
 
     /**
@@ -390,7 +390,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testDefaultIsReturnedWhenGettingNonExistentInputOnJsonRequest()
     {
         $request = JsonRequest::createFromGlobals();
-        $this->assertEquals('blah', $request->getInput('baz', 'blah'));
+        $this->assertSame('blah', $request->getInput('baz', 'blah'));
     }
 
     /**
@@ -450,7 +450,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
             $_SERVER['REQUEST_METHOD'] = $method;
             $_SERVER['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
             $request = FormUrlEncodedRequest::createFromGlobals();
-            $this->assertEquals('bar', $request->getInput('foo'));
+            $this->assertSame('bar', $request->getInput('foo'));
         }
     }
 
@@ -460,7 +460,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testEmptyStringWhenNoReferrerNorPreviousUrlIsSet()
     {
         $request = Request::createFromGlobals();
-        $this->assertEquals('', $request->getPreviousUrl());
+        $this->assertSame('', $request->getPreviousUrl());
     }
 
     /**
@@ -491,7 +491,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $url = 'https://foo.com:8080/bar/baz?dave=young';
         $request = Request::createFromUrl($url, 'GET');
-        $this->assertEquals($url, $request->getFullUrl());
+        $this->assertSame($url, $request->getFullUrl());
     }
 
     /**
@@ -501,7 +501,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $testBody = "It's not Rocket Appliances Julian";
         $this->request = new Request($_GET, $_POST, $_COOKIE, $_SERVER, $_FILES, $_ENV, $testBody);
-        $this->assertEquals($testBody, $this->request->getRawBody());
+        $this->assertSame($testBody, $this->request->getRawBody());
     }
 
     /**
@@ -511,7 +511,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'CONNECT';
         $this->request->getServer()->exchangeArray($_SERVER);
-        $this->assertEquals(RequestMethods::CONNECT, $this->request->getServer()->get('REQUEST_METHOD'));
+        $this->assertSame(RequestMethods::CONNECT, $this->request->getServer()->get('REQUEST_METHOD'));
     }
 
     /**
@@ -533,23 +533,23 @@ class RequestTest extends \PHPUnit\Framework\TestCase
             $_SERVER['REQUEST_METHOD'] = $method;
             $_SERVER['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
             $request = FormUrlEncodedRequest::createFromGlobals();
-            $this->assertEquals('foo=bar', $request->getRawBody());
+            $this->assertSame('foo=bar', $request->getRawBody());
 
             switch ($method) {
                 case 'PUT':
-                    $this->assertEquals('bar', $request->getPut()->get('foo'));
+                    $this->assertSame('bar', $request->getPut()->get('foo'));
                     $this->assertNull($request->getPatch()->get('foo'));
                     $this->assertNull($request->getDelete()->get('foo'));
 
                     break;
                 case 'PATCH':
-                    $this->assertEquals('bar', $request->getPatch()->get('foo'));
+                    $this->assertSame('bar', $request->getPatch()->get('foo'));
                     $this->assertNull($request->getPut()->get('foo'));
                     $this->assertNull($request->getDelete()->get('foo'));
 
                     break;
                 case 'DELETE':
-                    $this->assertEquals('bar', $request->getDelete()->get('foo'));
+                    $this->assertSame('bar', $request->getDelete()->get('foo'));
                     $this->assertNull($request->getPut()->get('foo'));
                     $this->assertNull($request->getPatch()->get('foo'));
 
@@ -573,19 +573,19 @@ class RequestTest extends \PHPUnit\Framework\TestCase
 
             switch ($method) {
                 case 'PUT':
-                    $this->assertEquals('bar', $request->getPut()->get('foo'));
+                    $this->assertSame('bar', $request->getPut()->get('foo'));
                     $this->assertNull($request->getPatch()->get('foo'));
                     $this->assertNull($request->getDelete()->get('foo'));
 
                     break;
                 case 'PATCH':
-                    $this->assertEquals('bar', $request->getPatch()->get('foo'));
+                    $this->assertSame('bar', $request->getPatch()->get('foo'));
                     $this->assertNull($request->getPut()->get('foo'));
                     $this->assertNull($request->getDelete()->get('foo'));
 
                     break;
                 case 'DELETE':
-                    $this->assertEquals('bar', $request->getDelete()->get('foo'));
+                    $this->assertSame('bar', $request->getDelete()->get('foo'));
                     $this->assertNull($request->getPut()->get('foo'));
                     $this->assertNull($request->getPatch()->get('foo'));
 
@@ -601,7 +601,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'DELETE';
         $this->request->getServer()->exchangeArray($_SERVER);
-        $this->assertEquals(RequestMethods::DELETE, $this->request->getServer()->get('REQUEST_METHOD'));
+        $this->assertSame(RequestMethods::DELETE, $this->request->getServer()->get('REQUEST_METHOD'));
     }
 
     /**
@@ -658,7 +658,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $this->request->getServer()->exchangeArray($_SERVER);
-        $this->assertEquals(RequestMethods::GET, $this->request->getServer()->get('REQUEST_METHOD'));
+        $this->assertSame(RequestMethods::GET, $this->request->getServer()->get('REQUEST_METHOD'));
     }
 
     /**
@@ -686,7 +686,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['HTTP_X_FORWARDED_HOST'] = '172.19.131.152, 10.33.185.152';
         $_SERVER['HTTP_HOST'] = '123.456.789.101';
         $request = Request::createFromGlobals();
-        $this->assertEquals('123.456.789.101', $request->getHost());
+        $this->assertSame('123.456.789.101', $request->getHost());
     }
 
     /**
@@ -696,7 +696,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['HTTP_HOST'] = 'foo.com';
         $request = Request::createFromGlobals();
-        $this->assertEquals('foo.com', $request->getHost());
+        $this->assertSame('foo.com', $request->getHost());
     }
 
     /**
@@ -706,7 +706,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['SERVER_ADDR'] = 'foo.com';
         $request = Request::createFromGlobals();
-        $this->assertEquals('foo.com', $request->getHost());
+        $this->assertSame('foo.com', $request->getHost());
     }
 
     /**
@@ -716,7 +716,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['SERVER_NAME'] = 'foo.com';
         $request = Request::createFromGlobals();
-        $this->assertEquals('foo.com', $request->getHost());
+        $this->assertSame('foo.com', $request->getHost());
     }
 
     /**
@@ -729,7 +729,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['SERVER_NAME'] = 'foo.com';
         $_SERVER['REQUEST_URI'] = '/bar';
         $request = Request::createFromGlobals();
-        $this->assertEquals('http://foo.com/bar', $request->getFullUrl());
+        $this->assertSame('http://foo.com/bar', $request->getFullUrl());
     }
 
     /**
@@ -743,7 +743,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['SERVER_NAME'] = 'foo.com';
         $_SERVER['REQUEST_URI'] = '/bar';
         $request = Request::createFromGlobals();
-        $this->assertEquals('https://foo.com/bar', $request->getFullUrl());
+        $this->assertSame('https://foo.com/bar', $request->getFullUrl());
     }
 
     /**
@@ -773,7 +773,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['REQUEST_METHOD'] = RequestMethods::GET;
         $_SERVER['X-HTTP-METHOD-OVERRIDE'] = RequestMethods::PUT;
         $request = Request::createFromGlobals();
-        $this->assertEquals(RequestMethods::GET, $request->getMethod());
+        $this->assertSame(RequestMethods::GET, $request->getMethod());
     }
 
     /**
@@ -784,7 +784,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['REQUEST_METHOD'] = RequestMethods::POST;
         $_SERVER['X-HTTP-METHOD-OVERRIDE'] = RequestMethods::PUT;
         $request = Request::createFromGlobals();
-        $this->assertEquals(RequestMethods::PUT, $request->getMethod());
+        $this->assertSame(RequestMethods::PUT, $request->getMethod());
     }
 
     /**
@@ -806,7 +806,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['SERVER_NAME'] = 'foo.com';
         $_SERVER['REQUEST_URI'] = '/bar';
         $request = Request::createFromGlobals();
-        $this->assertEquals('http://foo.com:8080/bar', $request->getFullUrl());
+        $this->assertSame('http://foo.com:8080/bar', $request->getFullUrl());
     }
 
     /**
@@ -816,7 +816,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
         $this->request->getServer()->exchangeArray($_SERVER);
-        $this->assertEquals(RequestMethods::OPTIONS, $this->request->getServer()->get('REQUEST_METHOD'));
+        $this->assertSame(RequestMethods::OPTIONS, $this->request->getServer()->get('REQUEST_METHOD'));
     }
 
     /**
@@ -826,7 +826,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['PHP_AUTH_PW'] = 'myPassword';
         $request = Request::createFromGlobals();
-        $this->assertEquals('myPassword', $request->getPassword());
+        $this->assertSame('myPassword', $request->getPassword());
     }
 
     /**
@@ -836,7 +836,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'PATCH';
         $this->request->getServer()->exchangeArray($_SERVER);
-        $this->assertEquals(RequestMethods::PATCH, $this->request->getServer()->get('REQUEST_METHOD'));
+        $this->assertSame(RequestMethods::PATCH, $this->request->getServer()->get('REQUEST_METHOD'));
     }
 
     /**
@@ -846,7 +846,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['REQUEST_URI'] = '/foo/bar/baz';
         $request = Request::createFromGlobals();
-        $this->assertEquals('/foo/bar/baz', $request->getPath());
+        $this->assertSame('/foo/bar/baz', $request->getPath());
     }
 
     /**
@@ -856,7 +856,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['REQUEST_URI'] = '';
         $request = Request::createFromGlobals();
-        $this->assertEquals('/', $request->getPath());
+        $this->assertSame('/', $request->getPath());
     }
 
     /**
@@ -866,7 +866,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['REQUEST_URI'] = '/foo/bar/baz?a=1&b=2';
         $request = Request::createFromGlobals();
-        $this->assertEquals('/foo/bar/baz', $request->getPath());
+        $this->assertSame('/foo/bar/baz', $request->getPath());
     }
 
     /**
@@ -884,7 +884,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $this->request->getServer()->exchangeArray($_SERVER);
-        $this->assertEquals(RequestMethods::POST, $this->request->getServer()->get('REQUEST_METHOD'));
+        $this->assertSame(RequestMethods::POST, $this->request->getServer()->get('REQUEST_METHOD'));
     }
 
     /**
@@ -894,7 +894,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'PURGE';
         $this->request->getServer()->exchangeArray($_SERVER);
-        $this->assertEquals(RequestMethods::PURGE, $this->request->getServer()->get('REQUEST_METHOD'));
+        $this->assertSame(RequestMethods::PURGE, $this->request->getServer()->get('REQUEST_METHOD'));
     }
 
     /**
@@ -904,7 +904,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'PUT';
         $this->request->getServer()->exchangeArray($_SERVER);
-        $this->assertEquals(RequestMethods::PUT, $this->request->getServer()->get('REQUEST_METHOD'));
+        $this->assertSame(RequestMethods::PUT, $this->request->getServer()->get('REQUEST_METHOD'));
     }
 
     /**
@@ -923,7 +923,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $queryString = 'foo=bar&blah=asdf';
         $_SERVER['QUERY_STRING'] = $queryString;
         $this->request->getServer()->exchangeArray($_SERVER);
-        $this->assertEquals($queryString, $this->request->getServer()->get('QUERY_STRING'));
+        $this->assertSame($queryString, $this->request->getServer()->get('QUERY_STRING'));
     }
 
     /**
@@ -941,7 +941,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['REQUEST_URI'] = '/foo/bar';
         $this->request->getServer()->exchangeArray($_SERVER);
-        $this->assertEquals('/foo/bar', $this->request->getServer()->get('REQUEST_URI'));
+        $this->assertSame('/foo/bar', $this->request->getServer()->get('REQUEST_URI'));
     }
 
     /**
@@ -968,7 +968,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_COOKIE['foo'] = 'bar';
         $this->request->getCookies()->exchangeArray($_COOKIE);
-        $this->assertEquals('bar', $this->request->getCookies()->get('foo'));
+        $this->assertSame('bar', $this->request->getCookies()->get('foo'));
     }
 
     /**
@@ -978,7 +978,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_GET['foo'] = 'bar';
         $this->request->getQuery()->exchangeArray($_GET);
-        $this->assertEquals('bar', $this->request->getQuery()->get('foo'));
+        $this->assertSame('bar', $this->request->getQuery()->get('foo'));
     }
 
     /**
@@ -988,7 +988,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_POST['foo'] = 'bar';
         $this->request->getPost()->exchangeArray($_POST);
-        $this->assertEquals('bar', $this->request->getPost()->get('foo'));
+        $this->assertSame('bar', $this->request->getPost()->get('foo'));
     }
 
     /**
@@ -998,7 +998,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'TRACE';
         $this->request->getServer()->exchangeArray($_SERVER);
-        $this->assertEquals(RequestMethods::TRACE, $this->request->getServer()->get('REQUEST_METHOD'));
+        $this->assertSame(RequestMethods::TRACE, $this->request->getServer()->get('REQUEST_METHOD'));
     }
 
     /**
@@ -1035,7 +1035,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['SERVER_NAME'] = 'foo.com';
         $_SERVER['REQUEST_URI'] = '/bar?baz=blah';
         $request = Request::createFromGlobals();
-        $this->assertEquals('http://foo.com/bar?baz=blah', $request->getFullUrl());
+        $this->assertSame('http://foo.com/bar?baz=blah', $request->getFullUrl());
     }
 
     /**
@@ -1045,7 +1045,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['PHP_AUTH_USER'] = 'dave';
         $request = Request::createFromGlobals();
-        $this->assertEquals('dave', $request->getUser());
+        $this->assertSame('dave', $request->getUser());
     }
 
     /**
@@ -1056,8 +1056,8 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
         $_SERVER['CONTENT_LENGTH'] = 24;
         $request = Request::createFromGlobals();
-        $this->assertEquals('application/x-www-form-urlencoded', $request->getHeaders()->get('CONTENT_TYPE'));
-        $this->assertEquals(24, $request->getHeaders()->get('CONTENT_LENGTH'));
+        $this->assertSame('application/x-www-form-urlencoded', $request->getHeaders()->get('CONTENT_TYPE'));
+        $this->assertSame(24, $request->getHeaders()->get('CONTENT_LENGTH'));
     }
 
     /**
@@ -1066,13 +1066,13 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testHostIsSetFromUrl()
     {
         $request = Request::createFromUrl('http://foo.com/bar', 'GET');
-        $this->assertEquals('foo.com', $request->getHost());
+        $this->assertSame('foo.com', $request->getHost());
         $request = Request::createFromUrl('http://foo.com:80/bar', 'GET');
-        $this->assertEquals('foo.com', $request->getHost());
+        $this->assertSame('foo.com', $request->getHost());
         $request = Request::createFromUrl('https://foo.com:443/bar', 'GET');
-        $this->assertEquals('foo.com', $request->getHost());
+        $this->assertSame('foo.com', $request->getHost());
         $request = Request::createFromUrl('http://foo.com:8080/bar', 'GET');
-        $this->assertEquals('foo.com', $request->getHost());
+        $this->assertSame('foo.com', $request->getHost());
     }
 
     /**
@@ -1084,7 +1084,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['REMOTE_ADDR'] = '192.168.2.1';
         Request::setTrustedProxies('192.168.2.1');
         $request = Request::createFromGlobals();
-        $this->assertEquals('bar.com', $request->getHost());
+        $this->assertSame('bar.com', $request->getHost());
     }
 
     /**
@@ -1186,7 +1186,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testJsonIsReturnedWhenGettingInputFromJsonRequest()
     {
         $request = JsonRequest::createFromGlobals();
-        $this->assertEquals('bar', $request->getInput('foo'));
+        $this->assertSame('bar', $request->getInput('foo'));
     }
 
     /**
@@ -1205,7 +1205,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $parameters = ['name' => 'val'];
         $request = Request::createFromUrl('/foo', 'GET', $parameters);
-        $this->assertEquals('val', $request->getQuery()->get('name'));
+        $this->assertSame('val', $request->getQuery()->get('name'));
     }
 
     /**
@@ -1215,7 +1215,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $parameters = ['name' => 'val'];
         $request = Request::createFromUrl('/foo', 'POST', $parameters);
-        $this->assertEquals('val', $request->getPost()->get('name'));
+        $this->assertSame('val', $request->getPost()->get('name'));
     }
 
     /**
@@ -1226,7 +1226,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_GET['_method'] = RequestMethods::PUT;
         $_SERVER['REQUEST_METHOD'] = RequestMethods::GET;
         $request = Request::createFromGlobals();
-        $this->assertEquals(RequestMethods::GET, $request->getMethod());
+        $this->assertSame(RequestMethods::GET, $request->getMethod());
     }
 
     /**
@@ -1237,7 +1237,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_POST['_method'] = RequestMethods::PUT;
         $_SERVER['REQUEST_METHOD'] = RequestMethods::POST;
         $request = Request::createFromGlobals();
-        $this->assertEquals(RequestMethods::PUT, $request->getMethod());
+        $this->assertSame(RequestMethods::PUT, $request->getMethod());
     }
 
     /**
@@ -1246,7 +1246,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testPathSetFromUrl()
     {
         $request = Request::createFromUrl('http://foo.com/bar', 'GET');
-        $this->assertEquals('/bar', $request->getPath());
+        $this->assertSame('/bar', $request->getPath());
     }
 
     /**
@@ -1258,7 +1258,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_SERVER['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
         $request = FormUrlEncodedRequest::createFromGlobals();
-        $this->assertEquals('blahblahblah', $request->getPost()->get('foo'));
+        $this->assertSame('blahblahblah', $request->getPost()->get('foo'));
     }
 
     /**
@@ -1269,7 +1269,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_POST['foo'] = 'bar';
         $request = Request::createFromGlobals();
-        $this->assertEquals('bar', $request->getInput('foo'));
+        $this->assertSame('bar', $request->getInput('foo'));
     }
 
     /**
@@ -1279,7 +1279,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['HTTP_REFERER'] = 'http://foo.com';
         $request = Request::createFromGlobals();
-        $this->assertEquals('http://foo.com', $request->getPreviousUrl());
+        $this->assertSame('http://foo.com', $request->getPreviousUrl());
         $this->assertEmpty($request->getPreviousUrl(false));
     }
 
@@ -1291,7 +1291,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['HTTP_REFERER'] = 'http://foo.com';
         $request = Request::createFromGlobals();
         $request->setPreviousUrl('http://bar.com');
-        $this->assertEquals('http://bar.com', $request->getPreviousUrl());
+        $this->assertSame('http://bar.com', $request->getPreviousUrl());
     }
 
     /**
@@ -1302,7 +1302,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_GET['foo'] = 'bar';
         $_POST['foo'] = 'baz';
         $request = Request::createFromGlobals();
-        $this->assertEquals('bar', $request->getInput('foo'));
+        $this->assertSame('bar', $request->getInput('foo'));
     }
 
     /**
@@ -1312,7 +1312,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_GET['foo'] = 'bar';
         $request = Request::createFromGlobals();
-        $this->assertEquals('bar', $request->getInput('foo'));
+        $this->assertSame('bar', $request->getInput('foo'));
     }
 
     /**
@@ -1323,7 +1323,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_GET['foo'] = 'bar';
         $request = Request::createFromGlobals();
-        $this->assertEquals('bar', $request->getInput('foo'));
+        $this->assertSame('bar', $request->getInput('foo'));
     }
 
     /**
@@ -1337,8 +1337,8 @@ class RequestTest extends \PHPUnit\Framework\TestCase
             'dave' => 'young'
         ];
         $this->assertEquals($expectedQuery, $request->getQuery()->getAll());
-        $this->assertEquals('/bar/?baz=blah&dave=young', $request->getServer()->get('REQUEST_URI'));
-        $this->assertEquals('baz=blah&dave=young', $request->getServer()->get('QUERY_STRING'));
+        $this->assertSame('/bar/?baz=blah&dave=young', $request->getServer()->get('REQUEST_URI'));
+        $this->assertSame('baz=blah&dave=young', $request->getServer()->get('QUERY_STRING'));
     }
 
     /**
@@ -1352,8 +1352,8 @@ class RequestTest extends \PHPUnit\Framework\TestCase
             'dave' => 'young'
         ];
         $this->assertEquals($expectedQuery, $request->getQuery()->getAll());
-        $this->assertEquals('/bar/?baz=yay&dave=young', $request->getServer()->get('REQUEST_URI'));
-        $this->assertEquals('baz=yay&dave=young', $request->getServer()->get('QUERY_STRING'));
+        $this->assertSame('/bar/?baz=yay&dave=young', $request->getServer()->get('REQUEST_URI'));
+        $this->assertSame('baz=yay&dave=young', $request->getServer()->get('QUERY_STRING'));
     }
 
     /**
@@ -1362,7 +1362,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testRawBodySetFromUrl()
     {
         $request = Request::createFromUrl('/foo', 'GET', [], [], [], [], [], 'foo-bar-baz');
-        $this->assertEquals('foo-bar-baz', $request->getRawBody());
+        $this->assertSame('foo-bar-baz', $request->getRawBody());
     }
 
     /**
@@ -1373,7 +1373,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $_SERVER['REMOTE_ADDR'] = '192.168.1.1';
         Request::setTrustedProxies('192.168.1.1');
         $request = Request::createFromGlobals();
-        $this->assertEquals('192.168.1.1', $request->getClientIPAddress());
+        $this->assertSame('192.168.1.1', $request->getClientIPAddress());
     }
 
     /**
@@ -1382,11 +1382,11 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testSchemeAndPortSetFromUrl()
     {
         $httpsRequest = Request::createFromUrl('https://foo.com/bar', 'GET');
-        $this->assertEquals('on', $httpsRequest->getServer()->get('HTTPS'));
-        $this->assertEquals(443, $httpsRequest->getServer()->get('SERVER_PORT'));
+        $this->assertSame('on', $httpsRequest->getServer()->get('HTTPS'));
+        $this->assertSame(443, $httpsRequest->getServer()->get('SERVER_PORT'));
         $httpRequest = Request::createFromUrl('http://foo.com/bar', 'GET');
         $this->assertFalse($httpRequest->getServer()->has('HTTPS'));
-        $this->assertEquals(80, $httpRequest->getServer()->get('SERVER_PORT'));
+        $this->assertSame(80, $httpRequest->getServer()->get('SERVER_PORT'));
     }
 
     /**
@@ -1443,7 +1443,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testSettingMethod()
     {
         $this->request->setMethod('put');
-        $this->assertEquals('PUT', $this->request->getMethod());
+        $this->assertSame('PUT', $this->request->getMethod());
     }
 
     /**
@@ -1452,7 +1452,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testSettingPath()
     {
         $this->request->setPath('/foo');
-        $this->assertEquals('/foo', $this->request->getPath());
+        $this->assertSame('/foo', $this->request->getPath());
     }
 
     /**
@@ -1462,6 +1462,6 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['HTTP_HOST'] = 'foo.com:8080';
         $request = Request::createFromGlobals();
-        $this->assertEquals('foo.com', $request->getHost());
+        $this->assertSame('foo.com', $request->getHost());
     }
 }

--- a/src/Opulence/Http/Tests/Requests/UploadedFileTest.php
+++ b/src/Opulence/Http/Tests/Requests/UploadedFileTest.php
@@ -88,7 +88,7 @@ class UploadedFileTest extends \PHPUnit\Framework\TestCase
             __DIR__ . self::TEMP_FILENAME,
             100
         );
-        $this->assertEquals(UPLOAD_ERR_OK, $file->getError());
+        $this->assertSame(UPLOAD_ERR_OK, $file->getError());
     }
 
     /**
@@ -116,7 +116,7 @@ class UploadedFileTest extends \PHPUnit\Framework\TestCase
             'text/plain',
             UPLOAD_ERR_EXTENSION
         );
-        $this->assertEquals(UPLOAD_ERR_EXTENSION, $file->getError());
+        $this->assertSame(UPLOAD_ERR_EXTENSION, $file->getError());
     }
 
     /**
@@ -130,7 +130,7 @@ class UploadedFileTest extends \PHPUnit\Framework\TestCase
             100,
             'foo/bar'
         );
-        $this->assertEquals('text/plain', $file->getMimeType());
+        $this->assertSame('text/plain', $file->getMimeType());
     }
 
     /**
@@ -138,7 +138,7 @@ class UploadedFileTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingPath()
     {
-        $this->assertEquals(__DIR__ . '/files', $this->file->getPath());
+        $this->assertSame(__DIR__ . '/files', $this->file->getPath());
     }
 
     /**
@@ -146,7 +146,7 @@ class UploadedFileTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingTempExtension()
     {
-        $this->assertEquals('txt', $this->file->getTempExtension());
+        $this->assertSame('txt', $this->file->getTempExtension());
     }
 
     /**
@@ -154,7 +154,7 @@ class UploadedFileTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingTempFilename()
     {
-        $this->assertEquals(__DIR__ . self::TEMP_FILENAME, $this->file->getTempFilename());
+        $this->assertSame(__DIR__ . self::TEMP_FILENAME, $this->file->getTempFilename());
     }
 
     /**
@@ -162,7 +162,7 @@ class UploadedFileTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingTempMimeType()
     {
-        $this->assertEquals('text/plain', $this->file->getTempMimeType());
+        $this->assertSame('text/plain', $this->file->getTempMimeType());
     }
 
     /**
@@ -170,7 +170,7 @@ class UploadedFileTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingTempSize()
     {
-        $this->assertEquals(100, $this->file->getTempSize());
+        $this->assertSame(100, $this->file->getTempSize());
     }
 
     /**
@@ -180,10 +180,10 @@ class UploadedFileTest extends \PHPUnit\Framework\TestCase
     {
         // Test specifying directory for target and a filename
         $this->file->move(__DIR__ . '/tmp', 'bar.txt');
-        $this->assertEquals('bar', file_get_contents(__DIR__ . '/tmp/bar.txt'));
+        $this->assertSame('bar', file_get_contents(__DIR__ . '/tmp/bar.txt'));
         // Test not specifying a name
         $this->file->move(__DIR__ . '/tmp');
-        $this->assertEquals('bar', file_get_contents(__DIR__ . '/tmp/UploadedFile.txt'));
+        $this->assertSame('bar', file_get_contents(__DIR__ . '/tmp/UploadedFile.txt'));
     }
 
     /**

--- a/src/Opulence/Http/Tests/Responses/CookieTest.php
+++ b/src/Opulence/Http/Tests/Responses/CookieTest.php
@@ -56,7 +56,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingDomain()
     {
-        $this->assertEquals($this->domain, $this->cookie->getDomain());
+        $this->assertSame($this->domain, $this->cookie->getDomain());
     }
 
     /**
@@ -64,7 +64,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingExpiration()
     {
-        $this->assertEquals($this->expiration->format('U'), $this->cookie->getExpiration());
+        $this->assertSame($this->expiration->format('U'), (string)$this->cookie->getExpiration());
     }
 
     /**
@@ -88,7 +88,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingName()
     {
-        $this->assertEquals($this->name, $this->cookie->getName());
+        $this->assertSame($this->name, $this->cookie->getName());
     }
 
     /**
@@ -96,7 +96,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingPath()
     {
-        $this->assertEquals($this->path, $this->cookie->getPath());
+        $this->assertSame($this->path, $this->cookie->getPath());
     }
 
     /**
@@ -114,7 +114,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
     {
         $time = time();
         $cookie = new Cookie($this->name, $this->value, $time);
-        $this->assertEquals($time, $cookie->getExpiration());
+        $this->assertSame($time, $cookie->getExpiration());
     }
 
     /**
@@ -131,7 +131,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
     public function testSameSiteReturnsWhatIsSetInConstructor()
     {
         $cookie = new Cookie($this->name, $this->value, time() + 3600, '/', '', false, false, 'lax');
-        $this->assertEquals('lax', $cookie->getSameSite());
+        $this->assertSame('lax', $cookie->getSameSite());
     }
 
     /**
@@ -140,7 +140,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
     public function testSettingDomain()
     {
         $this->cookie->setDomain('blah.com');
-        $this->assertEquals('blah.com', $this->cookie->getDomain());
+        $this->assertSame('blah.com', $this->cookie->getDomain());
     }
 
     /**
@@ -150,7 +150,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
     {
         $expiration = new DateTime('+1 day');
         $this->cookie->setExpiration($expiration);
-        $this->assertEquals($expiration->format('U'), $this->cookie->getExpiration());
+        $this->assertSame($expiration->format('U'), (string)$this->cookie->getExpiration());
     }
 
     /**
@@ -177,7 +177,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
     public function testSettingName()
     {
         $this->cookie->setName('blah');
-        $this->assertEquals('blah', $this->cookie->getName());
+        $this->assertSame('blah', $this->cookie->getName());
     }
 
     /**
@@ -186,7 +186,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
     public function testSettingPath()
     {
         $this->cookie->setPath('blah');
-        $this->assertEquals('blah', $this->cookie->getPath());
+        $this->assertSame('blah', $this->cookie->getPath());
     }
 
     /**
@@ -195,7 +195,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
     public function testSettingSameSite()
     {
         $this->cookie->setSameSite('strict');
-        $this->assertEquals('strict', $this->cookie->getSameSite());
+        $this->assertSame('strict', $this->cookie->getSameSite());
     }
 
     /**
@@ -204,6 +204,6 @@ class CookieTest extends \PHPUnit\Framework\TestCase
     public function testSettingValue()
     {
         $this->cookie->setValue('blah');
-        $this->assertEquals('blah', $this->cookie->getValue());
+        $this->assertSame('blah', $this->cookie->getValue());
     }
 }

--- a/src/Opulence/Http/Tests/Responses/JsonResponseTest.php
+++ b/src/Opulence/Http/Tests/Responses/JsonResponseTest.php
@@ -26,7 +26,7 @@ class JsonResponseTest extends \PHPUnit\Framework\TestCase
     public function testGettingContentType()
     {
         $response = new JsonResponse();
-        $this->assertEquals(ResponseHeaders::CONTENT_TYPE_JSON, $response->getHeaders()->get('Content-Type'));
+        $this->assertSame(ResponseHeaders::CONTENT_TYPE_JSON, $response->getHeaders()->get('Content-Type'));
     }
 
     /**
@@ -35,7 +35,7 @@ class JsonResponseTest extends \PHPUnit\Framework\TestCase
     public function testGettingStatusCodeAfterSettingInConstructor()
     {
         $response = new JsonResponse([], ResponseHeaders::HTTP_ACCEPTED);
-        $this->assertEquals(ResponseHeaders::HTTP_ACCEPTED, $response->getStatusCode());
+        $this->assertSame(ResponseHeaders::HTTP_ACCEPTED, $response->getStatusCode());
     }
 
     /**
@@ -105,6 +105,6 @@ class JsonResponseTest extends \PHPUnit\Framework\TestCase
     public function testSettingHeadersInConstructor()
     {
         $response = new JsonResponse([], ResponseHeaders::HTTP_OK, ['FOO' => 'bar']);
-        $this->assertEquals('bar', $response->getHeaders()->get('FOO'));
+        $this->assertSame('bar', $response->getHeaders()->get('FOO'));
     }
 }

--- a/src/Opulence/Http/Tests/Responses/RedirectResponseTest.php
+++ b/src/Opulence/Http/Tests/Responses/RedirectResponseTest.php
@@ -45,7 +45,7 @@ class RedirectResponseTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingStatusCodeAfterSettingInConstructor()
     {
-        $this->assertEquals(ResponseHeaders::HTTP_ACCEPTED, $this->redirectResponse->getStatusCode());
+        $this->assertSame(ResponseHeaders::HTTP_ACCEPTED, $this->redirectResponse->getStatusCode());
     }
 
     /**
@@ -53,8 +53,8 @@ class RedirectResponseTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingTargetUrlAfterSettingInConstructor()
     {
-        $this->assertEquals('/foo', $this->redirectResponse->getTargetUrl());
-        $this->assertEquals('/foo', $this->redirectResponse->getHeaders()->get('Location'));
+        $this->assertSame('/foo', $this->redirectResponse->getTargetUrl());
+        $this->assertSame('/foo', $this->redirectResponse->getHeaders()->get('Location'));
     }
 
     /**
@@ -63,7 +63,7 @@ class RedirectResponseTest extends \PHPUnit\Framework\TestCase
     public function testSettingTargetUrl()
     {
         $this->redirectResponse->setTargetUrl('/bar');
-        $this->assertEquals('/bar', $this->redirectResponse->getTargetUrl());
-        $this->assertEquals('/bar', $this->redirectResponse->getHeaders()->get('Location'));
+        $this->assertSame('/bar', $this->redirectResponse->getTargetUrl());
+        $this->assertSame('/bar', $this->redirectResponse->getHeaders()->get('Location'));
     }
 }

--- a/src/Opulence/Http/Tests/Responses/ResponseHeadersTest.php
+++ b/src/Opulence/Http/Tests/Responses/ResponseHeadersTest.php
@@ -55,8 +55,8 @@ class ResponseHeadersTest extends \PHPUnit\Framework\TestCase
         $this->headers->deleteCookie('bar');
         $deletedCookies = $this->headers->getCookies(true);
         $this->assertCount(2, $deletedCookies);
-        $this->assertEquals('foo', $deletedCookies[0]->getName());
-        $this->assertEquals('bar', $deletedCookies[1]->getName());
+        $this->assertSame('foo', $deletedCookies[0]->getName());
+        $this->assertSame('bar', $deletedCookies[1]->getName());
     }
 
     /**

--- a/src/Opulence/Http/Tests/Responses/ResponseTest.php
+++ b/src/Opulence/Http/Tests/Responses/ResponseTest.php
@@ -36,7 +36,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     public function testGettingContent()
     {
         $response = new Response('foo');
-        $this->assertEquals('foo', $response->getContent());
+        $this->assertSame('foo', $response->getContent());
     }
 
     /**
@@ -44,7 +44,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingDefaultHttpVersion()
     {
-        $this->assertEquals('1.1', $this->response->getHttpVersion());
+        $this->assertSame('1.1', $this->response->getHttpVersion());
     }
 
     /**
@@ -52,7 +52,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingDefaultStatusCode()
     {
-        $this->assertEquals(ResponseHeaders::HTTP_OK, $this->response->getStatusCode());
+        $this->assertSame(ResponseHeaders::HTTP_OK, $this->response->getStatusCode());
     }
 
     /**
@@ -65,7 +65,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $this->response->setContent('foo');
         ob_start();
         $this->response->sendContent();
-        $this->assertEquals('foo', ob_get_clean());
+        $this->assertSame('foo', ob_get_clean());
     }
 
     /**
@@ -74,7 +74,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     public function testSettingContent()
     {
         $this->response->setContent('foo');
-        $this->assertEquals('foo', $this->response->getContent());
+        $this->assertSame('foo', $this->response->getContent());
     }
 
     /**
@@ -84,7 +84,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     {
         $expiration = new DateTime('now');
         $this->response->setExpiration($expiration);
-        $this->assertEquals($expiration->format('r'), $this->response->getHeaders()->get('Expires'));
+        $this->assertSame($expiration->format('r'), $this->response->getHeaders()->get('Expires'));
     }
 
     /**
@@ -93,7 +93,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     public function testSettingHttpVersion()
     {
         $this->response->setHttpVersion('2.0');
-        $this->assertEquals('2.0', $this->response->getHttpVersion());
+        $this->assertSame('2.0', $this->response->getHttpVersion());
     }
 
     /**
@@ -102,7 +102,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     public function testSettingStatusCode()
     {
         $this->response->setStatusCode(ResponseHeaders::HTTP_ACCEPTED);
-        $this->assertEquals(ResponseHeaders::HTTP_ACCEPTED, $this->response->getStatusCode());
+        $this->assertSame(ResponseHeaders::HTTP_ACCEPTED, $this->response->getStatusCode());
     }
 
     /**
@@ -112,6 +112,6 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     {
         $this->response->setStatusCode(ResponseHeaders::HTTP_ACCEPTED,
             ResponseHeaders::$statusTexts[ResponseHeaders::HTTP_ACCEPTED]);
-        $this->assertEquals(ResponseHeaders::HTTP_ACCEPTED, $this->response->getStatusCode());
+        $this->assertSame(ResponseHeaders::HTTP_ACCEPTED, $this->response->getStatusCode());
     }
 }

--- a/src/Opulence/Http/Tests/Responses/StreamResponseTest.php
+++ b/src/Opulence/Http/Tests/Responses/StreamResponseTest.php
@@ -28,10 +28,10 @@ class StreamResponseTest extends \PHPUnit\Framework\TestCase
         });
         ob_start();
         $response->sendContent();
-        $this->assertEquals('foo', ob_get_clean());
+        $this->assertSame('foo', ob_get_clean());
         ob_start();
         $response->sendContent();
-        $this->assertEquals('', ob_get_clean());
+        $this->assertSame('', ob_get_clean());
     }
 
     /**
@@ -42,7 +42,7 @@ class StreamResponseTest extends \PHPUnit\Framework\TestCase
         $response = new StreamResponse();
         ob_start();
         $response->sendContent();
-        $this->assertEquals('', ob_get_clean());
+        $this->assertSame('', ob_get_clean());
     }
 
     /**
@@ -66,6 +66,6 @@ class StreamResponseTest extends \PHPUnit\Framework\TestCase
         });
         ob_start();
         $response->sendContent();
-        $this->assertEquals('foo', ob_get_clean());
+        $this->assertSame('foo', ob_get_clean());
     }
 }

--- a/src/Opulence/IO/Tests/FileSystemTest.php
+++ b/src/Opulence/IO/Tests/FileSystemTest.php
@@ -45,7 +45,7 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase
     {
         file_put_contents(__DIR__ . '/test.txt', 'foo');
         $this->fileSystem->append(__DIR__ . '/test.txt', ' bar');
-        $this->assertEquals('foo bar', $this->fileSystem->read(__DIR__ . '/test.txt'));
+        $this->assertSame('foo bar', $this->fileSystem->read(__DIR__ . '/test.txt'));
     }
 
     /**
@@ -77,7 +77,7 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase
     {
         file_put_contents(__DIR__ . '/test.txt', 'foo');
         $this->assertTrue($this->fileSystem->copyFile(__DIR__ . '/test.txt', __DIR__ . '/test2.txt'));
-        $this->assertEquals('foo', $this->fileSystem->read(__DIR__ . '/test2.txt'));
+        $this->assertSame('foo', $this->fileSystem->read(__DIR__ . '/test2.txt'));
         @unlink(__DIR__ . '/test2.txt');
     }
 
@@ -123,7 +123,7 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingBasename()
     {
-        $this->assertEquals('foo.txt', $this->fileSystem->getBasename(__DIR__ . '/files/subdirectory/foo.txt'));
+        $this->assertSame('foo.txt', $this->fileSystem->getBasename(__DIR__ . '/files/subdirectory/foo.txt'));
         $this->expectException(FileSystemException::class);
         $this->fileSystem->getBasename(__DIR__ . '/doesnotexist.txt');
     }
@@ -155,7 +155,7 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingDirectoryName()
     {
-        $this->assertEquals(__DIR__ . '/files/subdirectory',
+        $this->assertSame(__DIR__ . '/files/subdirectory',
             $this->fileSystem->getDirectoryName(__DIR__ . '/files/subdirectory/foo.txt'));
         $this->expectException(FileSystemException::class);
         $this->fileSystem->getDirectoryName(__DIR__ . '/doesnotexist.txt');
@@ -166,7 +166,7 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingExtension()
     {
-        $this->assertEquals('txt', $this->fileSystem->getExtension(__DIR__ . '/files/subdirectory/foo.txt'));
+        $this->assertSame('txt', $this->fileSystem->getExtension(__DIR__ . '/files/subdirectory/foo.txt'));
         $this->expectException(FileSystemException::class);
         $this->fileSystem->getExtension(__DIR__ . '/doesnotexist.txt');
     }
@@ -176,7 +176,7 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingFileName()
     {
-        $this->assertEquals('foo', $this->fileSystem->getFileName(__DIR__ . '/files/subdirectory/foo.txt'));
+        $this->assertSame('foo', $this->fileSystem->getFileName(__DIR__ . '/files/subdirectory/foo.txt'));
         $this->expectException(FileSystemException::class);
         $this->fileSystem->getFileName(__DIR__ . '/doesnotexist.txt');
     }
@@ -298,7 +298,7 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->fileSystem->move(__DIR__ . '/test.txt', __DIR__ . '/test2.txt'));
         $this->assertFalse($this->fileSystem->exists(__DIR__ . '/test.txt'));
         $this->assertTrue($this->fileSystem->exists(__DIR__ . '/test2.txt'));
-        $this->assertEquals('foo bar', $this->fileSystem->read(__DIR__ . '/test2.txt'));
+        $this->assertSame('foo bar', $this->fileSystem->read(__DIR__ . '/test2.txt'));
         @unlink(__DIR__ . '/test2.txt');
     }
 
@@ -308,7 +308,7 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase
     public function testReadingFileThatDoesNotExist()
     {
         $this->expectException(FileSystemException::class);
-        $this->assertEquals('foo', $this->fileSystem->read(__DIR__ . '/doesnotexist.txt'));
+        $this->assertSame('foo', $this->fileSystem->read(__DIR__ . '/doesnotexist.txt'));
     }
 
     /**
@@ -317,7 +317,7 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase
     public function testReadingFileThatExists()
     {
         file_put_contents(__DIR__ . '/test.txt', 'foo');
-        $this->assertEquals('foo', $this->fileSystem->read(__DIR__ . '/test.txt'));
+        $this->assertSame('foo', $this->fileSystem->read(__DIR__ . '/test.txt'));
     }
 
     /**
@@ -342,7 +342,7 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase
      */
     public function testWritingToFile()
     {
-        $this->assertTrue(is_numeric($this->fileSystem->write(__DIR__ . '/test.txt', 'foo bar')));
-        $this->assertEquals('foo bar', $this->fileSystem->read(__DIR__ . '/test.txt'));
+        $this->assertIsNumeric($this->fileSystem->write(__DIR__ . '/test.txt', 'foo bar'));
+        $this->assertSame('foo bar', $this->fileSystem->read(__DIR__ . '/test.txt'));
     }
 }

--- a/src/Opulence/IO/Tests/Streams/MultiStreamTest.php
+++ b/src/Opulence/IO/Tests/Streams/MultiStreamTest.php
@@ -66,7 +66,7 @@ class MultiStreamTest extends \PHPUnit\Framework\TestCase
         $this->multiStream->addStream($unseekableStream);
         $this->multiStream->close();
         $this->assertTrue($this->multiStream->isSeekable());
-        $this->assertEquals(0, $this->multiStream->getPosition());
+        $this->assertSame(0, $this->multiStream->getPosition());
     }
 
     /**
@@ -116,7 +116,7 @@ class MultiStreamTest extends \PHPUnit\Framework\TestCase
         $destinationStream = new Stream(fopen('php://temp', 'r+'));
         $this->multiStream->copyToStream($destinationStream, 1);
         $destinationStream->rewind();
-        $this->assertEquals('foobar', $destinationStream->readToEnd());
+        $this->assertSame('foobar', $destinationStream->readToEnd());
     }
 
     /**
@@ -202,7 +202,7 @@ class MultiStreamTest extends \PHPUnit\Framework\TestCase
             ->willReturn(20);
         $this->multiStream->addStream($stream1);
         $this->multiStream->addStream($stream2);
-        $this->assertEquals(30, $this->multiStream->getLength());
+        $this->assertSame(30, $this->multiStream->getLength());
     }
 
     /**
@@ -253,7 +253,7 @@ class MultiStreamTest extends \PHPUnit\Framework\TestCase
      */
     public function testReadingEmptyStreamReturnsEmptyString() : void
     {
-        $this->assertEquals('', $this->multiStream->read(123));
+        $this->assertSame('', $this->multiStream->read(123));
     }
 
     /**
@@ -273,8 +273,8 @@ class MultiStreamTest extends \PHPUnit\Framework\TestCase
             ->willReturn('o');
         $this->multiStream->addStream($stream1);
         $this->multiStream->addStream($stream2);
-        $this->assertEquals('foo', $this->multiStream->read(3));
-        $this->assertEquals(3, $this->multiStream->getPosition());
+        $this->assertSame('foo', $this->multiStream->read(3));
+        $this->assertSame(3, $this->multiStream->getPosition());
     }
 
     /**
@@ -288,7 +288,7 @@ class MultiStreamTest extends \PHPUnit\Framework\TestCase
             ->with(3)
             ->willReturn('foo');
         $this->multiStream->addStream($stream);
-        $this->assertEquals('foo', $this->multiStream->read(3));
+        $this->assertSame('foo', $this->multiStream->read(3));
     }
 
     /**
@@ -303,10 +303,10 @@ class MultiStreamTest extends \PHPUnit\Framework\TestCase
         $this->multiStream->addStream($stream1);
         $this->multiStream->addStream($stream2);
         $this->multiStream->rewind();
-        $this->assertEquals('abcde', $this->multiStream->readToEnd());
+        $this->assertSame('abcde', $this->multiStream->readToEnd());
         $this->assertTrue($this->multiStream->isEof());
         $this->multiStream->seek(1);
-        $this->assertEquals('bcde', $this->multiStream->readToEnd());
+        $this->assertSame('bcde', $this->multiStream->readToEnd());
         $this->assertTrue($this->multiStream->isEof());
     }
 
@@ -315,7 +315,7 @@ class MultiStreamTest extends \PHPUnit\Framework\TestCase
      */
     public function testReadingToEndWithNoStreamsReturnsEmptyString() : void
     {
-        $this->assertEquals('', $this->multiStream->readToEnd());
+        $this->assertSame('', $this->multiStream->readToEnd());
     }
 
     /**
@@ -327,7 +327,7 @@ class MultiStreamTest extends \PHPUnit\Framework\TestCase
         $stream->write('foo');
         $this->multiStream->addStream($stream);
         $this->multiStream->seek(1);
-        $this->assertEquals('oo', $this->multiStream->readToEnd());
+        $this->assertSame('oo', $this->multiStream->readToEnd());
         $this->assertTrue($this->multiStream->isEof());
     }
 
@@ -361,29 +361,29 @@ class MultiStreamTest extends \PHPUnit\Framework\TestCase
         $this->multiStream->addStream($stream3);
 
         $this->multiStream->seek(1);
-        $this->assertEquals(1, $stream1->getPosition());
-        $this->assertEquals(0, $stream2->getPosition());
-        $this->assertEquals(0, $stream3->getPosition());
+        $this->assertSame(1, $stream1->getPosition());
+        $this->assertSame(0, $stream2->getPosition());
+        $this->assertSame(0, $stream3->getPosition());
 
         $this->multiStream->seek(3);
-        $this->assertEquals(3, $stream1->getPosition());
-        $this->assertEquals(0, $stream2->getPosition());
-        $this->assertEquals(0, $stream3->getPosition());
+        $this->assertSame(3, $stream1->getPosition());
+        $this->assertSame(0, $stream2->getPosition());
+        $this->assertSame(0, $stream3->getPosition());
 
         $this->multiStream->seek(4);
-        $this->assertEquals(3, $stream1->getPosition());
-        $this->assertEquals(1, $stream2->getPosition());
-        $this->assertEquals(0, $stream3->getPosition());
+        $this->assertSame(3, $stream1->getPosition());
+        $this->assertSame(1, $stream2->getPosition());
+        $this->assertSame(0, $stream3->getPosition());
 
         $this->multiStream->seek(5);
-        $this->assertEquals(3, $stream1->getPosition());
-        $this->assertEquals(2, $stream2->getPosition());
-        $this->assertEquals(0, $stream3->getPosition());
+        $this->assertSame(3, $stream1->getPosition());
+        $this->assertSame(2, $stream2->getPosition());
+        $this->assertSame(0, $stream3->getPosition());
 
         $this->multiStream->seek(6);
-        $this->assertEquals(3, $stream1->getPosition());
-        $this->assertEquals(2, $stream2->getPosition());
-        $this->assertEquals(1, $stream3->getPosition());
+        $this->assertSame(3, $stream1->getPosition());
+        $this->assertSame(2, $stream2->getPosition());
+        $this->assertSame(1, $stream3->getPosition());
     }
 
     /**
@@ -395,11 +395,11 @@ class MultiStreamTest extends \PHPUnit\Framework\TestCase
         $stream->write('foobar');
         $this->multiStream->addStream($stream);
         $this->multiStream->seek(1);
-        $this->assertEquals(1, $stream->getPosition());
+        $this->assertSame(1, $stream->getPosition());
         $this->multiStream->seek(2, SEEK_CUR);
-        $this->assertEquals(3, $stream->getPosition());
+        $this->assertSame(3, $stream->getPosition());
         $this->multiStream->seek(-1, SEEK_END);
-        $this->assertEquals(5, $stream->getPosition());
+        $this->assertSame(5, $stream->getPosition());
     }
 
     /**
@@ -443,7 +443,7 @@ class MultiStreamTest extends \PHPUnit\Framework\TestCase
         $stream2->seek(1);
         $this->multiStream->addStream($stream1);
         $this->multiStream->addStream($stream2);
-        $this->assertEquals('foobar', (string)$this->multiStream);
+        $this->assertSame('foobar', (string)$this->multiStream);
     }
 
     /**

--- a/src/Opulence/IO/Tests/Streams/StreamTest.php
+++ b/src/Opulence/IO/Tests/Streams/StreamTest.php
@@ -38,7 +38,7 @@ class StreamTest extends \PHPUnit\Framework\TestCase
         $stream = new Stream($handle);
         $stream->write('foo');
         $stream->close();
-        $this->assertEquals('', (string)$stream);
+        $this->assertSame('', (string)$stream);
     }
 
     /**
@@ -50,7 +50,7 @@ class StreamTest extends \PHPUnit\Framework\TestCase
         $stream = new Stream($handle);
         $stream->write('foo');
         $stream->read(1);
-        $this->assertEquals('foo', (string)$stream);
+        $this->assertSame('foo', (string)$stream);
     }
 
     /**
@@ -89,7 +89,7 @@ class StreamTest extends \PHPUnit\Framework\TestCase
         $destinationStream = new Stream(fopen('php://temp', 'r+'));
         $sourceStream->copyToStream($destinationStream, 1);
         $destinationStream->rewind();
-        $this->assertEquals('foo', $destinationStream->readToEnd());
+        $this->assertSame('foo', $destinationStream->readToEnd());
     }
 
     /**
@@ -207,7 +207,7 @@ class StreamTest extends \PHPUnit\Framework\TestCase
     {
         $handle = fopen('php://temp', 'r');
         $stream = new Stream($handle, 724);
-        $this->assertEquals(724, $stream->getLength());
+        $this->assertSame(724, $stream->getLength());
     }
 
     /**
@@ -227,7 +227,7 @@ class StreamTest extends \PHPUnit\Framework\TestCase
         $handle = fopen('php://temp', 'w+');
         $stream = new Stream($handle);
         $stream->write('foo');
-        $this->assertEquals(3, $stream->getPosition());
+        $this->assertSame(3, $stream->getPosition());
     }
 
     /**
@@ -288,7 +288,7 @@ class StreamTest extends \PHPUnit\Framework\TestCase
         $handle = fopen('php://temp', 'r');
         $expectedLength = fstat($handle)['size'];
         $stream = new Stream($handle);
-        $this->assertEquals($expectedLength, $stream->getLength());
+        $this->assertSame($expectedLength, $stream->getLength());
     }
 
     /**
@@ -299,9 +299,9 @@ class StreamTest extends \PHPUnit\Framework\TestCase
         $handle = fopen('php://temp', 'w+');
         $stream = new Stream($handle);
         $stream->write('foo');
-        $this->assertEquals('', $stream->readToEnd());
+        $this->assertSame('', $stream->readToEnd());
         $stream->rewind();
-        $this->assertEquals('foo', $stream->readToEnd());
+        $this->assertSame('foo', $stream->readToEnd());
     }
 
     /**
@@ -314,10 +314,10 @@ class StreamTest extends \PHPUnit\Framework\TestCase
         $stream->write('foo');
         $stream->rewind();
         $stream->seek(1);
-        $this->assertEquals('oo', $stream->readToEnd());
+        $this->assertSame('oo', $stream->readToEnd());
         $stream->rewind();
         $stream->seek(2);
-        $this->assertEquals('o', $stream->readToEnd());
+        $this->assertSame('o', $stream->readToEnd());
     }
 
     /**
@@ -340,6 +340,6 @@ class StreamTest extends \PHPUnit\Framework\TestCase
         $stream = new Stream($handle);
         $stream->write('foo');
         $stream->rewind();
-        $this->assertEquals('foo', $stream->readToEnd());
+        $this->assertSame('foo', $stream->readToEnd());
     }
 }

--- a/src/Opulence/Ioc/Tests/Bootstrappers/Dispatchers/BootstrapperDispatcherTest.php
+++ b/src/Opulence/Ioc/Tests/Bootstrappers/Dispatchers/BootstrapperDispatcherTest.php
@@ -83,7 +83,7 @@ class BootstrapperDispatcherTest extends \PHPUnit\Framework\TestCase
         $this->bootstrapperRegistry->registerLazyBootstrapper([LazyFooInterface::class], LazyBootstrapper::class);
         ob_start();
         $this->dispatcher->dispatch(false);
-        $this->assertEquals(LazyConcreteFoo::class, ob_get_clean());
+        $this->assertSame(LazyConcreteFoo::class, ob_get_clean());
     }
 
     /**
@@ -99,7 +99,7 @@ class BootstrapperDispatcherTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $this->dispatcher->dispatch(false);
         $this->container->resolve(EagerFooInterface::class);
-        $this->assertEquals(LazyConcreteFoo::class, ob_get_clean());
+        $this->assertSame(LazyConcreteFoo::class, ob_get_clean());
     }
 
     /**
@@ -115,7 +115,7 @@ class BootstrapperDispatcherTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $this->dispatcher->dispatch(false);
         $this->container->resolve(EagerFooInterface::class);
-        $this->assertEquals(LazyConcreteFoo::class, ob_get_clean());
+        $this->assertSame(LazyConcreteFoo::class, ob_get_clean());
     }
 
     /**

--- a/src/Opulence/Ioc/Tests/ClassBindingTest.php
+++ b/src/Opulence/Ioc/Tests/ClassBindingTest.php
@@ -44,7 +44,7 @@ class ClassBindingTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingConcreteClass()
     {
-        $this->assertEquals('foo', $this->binding->getConcreteClass());
+        $this->assertSame('foo', $this->binding->getConcreteClass());
     }
 
     /**

--- a/src/Opulence/Ioc/Tests/ContainerTest.php
+++ b/src/Opulence/Ioc/Tests/ContainerTest.php
@@ -171,7 +171,7 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
             },
             ['foo']
         );
-        $this->assertEquals('foo', $result);
+        $this->assertSame('foo', $result);
     }
 
     /**
@@ -200,7 +200,7 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
             },
             ['foo']
         );
-        $this->assertEquals($this->concreteFoo . ':foo', $response);
+        $this->assertSame($this->concreteFoo . ':foo', $response);
     }
 
     /**
@@ -217,7 +217,7 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
                 return get_class($interface);
             }
         );
-        $this->assertEquals($this->concreteFoo, $response);
+        $this->assertSame($this->concreteFoo, $response);
     }
 
     /**
@@ -529,8 +529,8 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
         $instance2 = $this->container->resolve($this->constructorWithInterfacesAndPrimitives);
         $this->assertInstanceOf($this->constructorWithInterfacesAndPrimitives, $instance1);
         $this->assertSame($instance1, $instance2);
-        $this->assertEquals(23, $instance1->getId());
-        $this->assertEquals(23, $instance2->getId());
+        $this->assertSame(23, $instance1->getId());
+        $this->assertSame(23, $instance2->getId());
     }
 
     /**
@@ -568,7 +568,7 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
         /** @var ConstructorWithMixOfConcreteClassesAndPrimitives $instance */
         $instance = $this->container->resolve($this->constructorWithConcreteClassesAndPrimitives);
         $this->assertInstanceOf($this->constructorWithConcreteClassesAndPrimitives, $instance);
-        $this->assertEquals(23, $instance->getId());
+        $this->assertSame(23, $instance->getId());
         $this->assertNotSame($instance, $this->container->resolve($this->constructorWithConcreteClassesAndPrimitives));
     }
 
@@ -582,7 +582,7 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
         $instance = $this->container->resolve($this->constructorWithConcreteClassesAndPrimitives);
         /** @var ConstructorWithMixOfConcreteClassesAndPrimitives $newInstance */
         $this->assertInstanceOf($this->constructorWithConcreteClassesAndPrimitives, $instance);
-        $this->assertEquals(23, $instance->getId());
+        $this->assertSame(23, $instance->getId());
         $this->assertSame($instance, $this->container->resolve($this->constructorWithConcreteClassesAndPrimitives));
     }
 
@@ -715,8 +715,8 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
         $instance2 = $this->container->resolve($this->constructorWithInterfacesAndPrimitives);
         $this->assertInstanceOf($this->constructorWithInterfacesAndPrimitives, $instance1);
         $this->assertSame($instance1, $instance2);
-        $this->assertEquals(23, $instance1->getId());
-        $this->assertEquals(23, $instance2->getId());
+        $this->assertSame(23, $instance1->getId());
+        $this->assertSame(23, $instance2->getId());
         $this->assertSame($instance1->getPerson(), $instance2->getPerson());
     }
 

--- a/src/Opulence/Memcached/Tests/MemcachedTest.php
+++ b/src/Opulence/Memcached/Tests/MemcachedTest.php
@@ -45,7 +45,7 @@ class MemcachedTest extends \PHPUnit\Framework\TestCase
                 'foo' => $foo
             ]
         );
-        $this->assertEquals('foo', $memcached->get('baz'));
+        $this->assertSame('foo', $memcached->get('baz'));
     }
 
     /**

--- a/src/Opulence/Memcached/Tests/Types/TypeMapperTest.php
+++ b/src/Opulence/Memcached/Tests/Types/TypeMapperTest.php
@@ -44,7 +44,7 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     public function testConvertingFromMemcachedTimestamp()
     {
         $time = new DateTime('now');
-        $this->assertEquals($time->getTimestamp(),
+        $this->assertSame($time->getTimestamp(),
             $this->typeMapper->fromMemcachedTimestamp($time->getTimestamp())->getTimestamp());
     }
 
@@ -70,7 +70,7 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     public function testConvertingToMemcachedTimestamp()
     {
         $time = new DateTime('now');
-        $this->assertEquals($time->getTimestamp(), $this->typeMapper->toMemcachedTimestamp($time));
+        $this->assertSame($time->getTimestamp(), $this->typeMapper->toMemcachedTimestamp($time));
     }
 
     /**
@@ -79,7 +79,7 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     public function testConvertingToMemcachedTimestampFromImmutable()
     {
         $time = new DateTimeImmutable('now');
-        $this->assertEquals($time->getTimestamp(), $this->typeMapper->toMemcachedTimestamp($time));
+        $this->assertSame($time->getTimestamp(), $this->typeMapper->toMemcachedTimestamp($time));
     }
 
     /**
@@ -100,7 +100,7 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
         date_default_timezone_set($newTimezone);
         $time = new DateTime('now');
         $memcachedTime = $this->typeMapper->fromMemcachedTimestamp($time->getTimestamp());
-        $this->assertEquals($newTimezone, $memcachedTime->getTimezone()->getName());
+        $this->assertSame($newTimezone, $memcachedTime->getTimezone()->getName());
         // Reset the timezone
         date_default_timezone_set($currTimezone);
     }

--- a/src/Opulence/Orm/Tests/EntityRegistryTest.php
+++ b/src/Opulence/Orm/Tests/EntityRegistryTest.php
@@ -102,8 +102,8 @@ class EntityRegistryTest extends \PHPUnit\Framework\TestCase
         $this->entityRegistry->clear();
         $this->assertFalse($this->entityRegistry->isRegistered($this->entity1));
         $this->assertFalse($this->entityRegistry->isRegistered($this->entity2));
-        $this->assertEquals(EntityStates::NEVER_REGISTERED, $this->entityRegistry->getEntityState($this->entity1));
-        $this->assertEquals(EntityStates::NEVER_REGISTERED, $this->entityRegistry->getEntityState($this->entity2));
+        $this->assertSame(EntityStates::NEVER_REGISTERED, $this->entityRegistry->getEntityState($this->entity1));
+        $this->assertSame(EntityStates::NEVER_REGISTERED, $this->entityRegistry->getEntityState($this->entity2));
     }
 
     /**
@@ -142,7 +142,7 @@ class EntityRegistryTest extends \PHPUnit\Framework\TestCase
         $this->entityRegistry->registerEntity($this->entity1);
         $this->entityRegistry->deregisterEntity($this->entity1);
         $this->assertFalse($this->entityRegistry->isRegistered($this->entity1));
-        $this->assertEquals(EntityStates::UNREGISTERED, $this->entityRegistry->getEntityState($this->entity1));
+        $this->assertSame(EntityStates::UNREGISTERED, $this->entityRegistry->getEntityState($this->entity1));
     }
 
     /**
@@ -164,7 +164,7 @@ class EntityRegistryTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingClassName()
     {
-        $this->assertEquals(get_class($this->entity1), $this->entityRegistry->getClassName($this->entity1));
+        $this->assertInstanceOf($this->entityRegistry->getClassName($this->entity1), $this->entity1);
     }
 
     /**
@@ -191,7 +191,7 @@ class EntityRegistryTest extends \PHPUnit\Framework\TestCase
     public function testGettingEntityStateForRegisteredEntity()
     {
         $this->entityRegistry->registerEntity($this->entity1);
-        $this->assertEquals(EntityStates::REGISTERED, $this->entityRegistry->getEntityState($this->entity1));
+        $this->assertSame(EntityStates::REGISTERED, $this->entityRegistry->getEntityState($this->entity1));
     }
 
     /**
@@ -199,7 +199,7 @@ class EntityRegistryTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingEntityStateForUnregisteredEntity()
     {
-        $this->assertEquals(EntityStates::NEVER_REGISTERED, $this->entityRegistry->getEntityState($this->entity1));
+        $this->assertSame(EntityStates::NEVER_REGISTERED, $this->entityRegistry->getEntityState($this->entity1));
     }
 
     /**
@@ -216,7 +216,7 @@ class EntityRegistryTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingObjectHashId()
     {
-        $this->assertEquals(spl_object_hash($this->entity1), $this->entityRegistry->getObjectHashId($this->entity1));
+        $this->assertSame(spl_object_hash($this->entity1), $this->entityRegistry->getObjectHashId($this->entity1));
     }
 
     /**
@@ -239,7 +239,7 @@ class EntityRegistryTest extends \PHPUnit\Framework\TestCase
     {
         $this->entityRegistry->registerEntity($this->entity1);
         $this->entityRegistry->setState($this->entity1, EntityStates::DEQUEUED);
-        $this->assertEquals(EntityStates::DEQUEUED, $this->entityRegistry->getEntityState($this->entity1));
+        $this->assertSame(EntityStates::DEQUEUED, $this->entityRegistry->getEntityState($this->entity1));
     }
 
     /**
@@ -260,7 +260,7 @@ class EntityRegistryTest extends \PHPUnit\Framework\TestCase
                 $child->setSecondAggregateRootId($aggregateRoot->getId());
             });
         $this->entityRegistry->runAggregateRootCallbacks($this->entity3);
-        $this->assertEquals($this->entity1->getId(), $this->entity3->getAggregateRootId());
-        $this->assertEquals($this->entity2->getId(), $this->entity3->getSecondAggregateRootId());
+        $this->assertSame($this->entity1->getId(), $this->entity3->getAggregateRootId());
+        $this->assertSame($this->entity2->getId(), $this->entity3->getSecondAggregateRootId());
     }
 }

--- a/src/Opulence/Orm/Tests/Ids/Accessors/IdAccessorRegistryTest.php
+++ b/src/Opulence/Orm/Tests/Ids/Accessors/IdAccessorRegistryTest.php
@@ -62,9 +62,9 @@ class IdAccessorRegistryTest extends \PHPUnit\Framework\TestCase
         $entity->expects($this->at(2))
             ->method('getId')
             ->willReturn(2);
-        $this->assertEquals(1, $this->registry->getEntityId($entity));
+        $this->assertSame(1, $this->registry->getEntityId($entity));
         $this->registry->setEntityId($entity, 2);
-        $this->assertEquals(2, $this->registry->getEntityId($entity));
+        $this->assertSame(2, $this->registry->getEntityId($entity));
     }
 
     /**
@@ -72,7 +72,7 @@ class IdAccessorRegistryTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingEntityId()
     {
-        $this->assertEquals(724, $this->registry->getEntityId($this->entity1));
+        $this->assertSame(724, $this->registry->getEntityId($this->entity1));
     }
 
     /**
@@ -106,7 +106,7 @@ class IdAccessorRegistryTest extends \PHPUnit\Framework\TestCase
         $this->registry->registerReflectionIdAccessors(Foo::class, 'id');
         $foo = new Foo();
         $this->registry->setEntityId($foo, 24);
-        $this->assertEquals(24, $this->registry->getEntityId($foo));
+        $this->assertSame(24, $this->registry->getEntityId($foo));
     }
 
     /**
@@ -119,8 +119,8 @@ class IdAccessorRegistryTest extends \PHPUnit\Framework\TestCase
         $bar = new Bar();
         $this->registry->setEntityId($foo, 24);
         $this->registry->setEntityId($bar, 42);
-        $this->assertEquals(24, $this->registry->getEntityId($foo));
-        $this->assertEquals(42, $this->registry->getEntityId($bar));
+        $this->assertSame(24, $this->registry->getEntityId($foo));
+        $this->assertSame(42, $this->registry->getEntityId($bar));
     }
 
     /**
@@ -150,9 +150,9 @@ class IdAccessorRegistryTest extends \PHPUnit\Framework\TestCase
             $entity->setId($id);
         };
         $this->registry->registerIdAccessors(['FooEntity', 'BarEntity'], $getter, $setter);
-        $this->assertEquals(123, $this->registry->getEntityId($entity1));
+        $this->assertSame(123, $this->registry->getEntityId($entity1));
         $this->registry->setEntityId($entity1, 123);
-        $this->assertEquals(123, $this->registry->getEntityId($entity2));
+        $this->assertSame(123, $this->registry->getEntityId($entity2));
         $this->registry->setEntityId($entity2, 456);
     }
 
@@ -162,7 +162,7 @@ class IdAccessorRegistryTest extends \PHPUnit\Framework\TestCase
     public function testSettingEntityId()
     {
         $this->registry->setEntityId($this->entity1, 333);
-        $this->assertEquals(333, $this->entity1->getId());
+        $this->assertSame(333, $this->entity1->getId());
     }
 
     /**

--- a/src/Opulence/Orm/Tests/Ids/Generators/UuidV4GeneratorTest.php
+++ b/src/Opulence/Orm/Tests/Ids/Generators/UuidV4GeneratorTest.php
@@ -37,8 +37,8 @@ class UuidV4GeneratorTest extends \PHPUnit\Framework\TestCase
         $id1 = $idGenerator->generate($entity);
         $id2 = $idGenerator->generate($entity);
         $this->assertNotSame($id1, $id2);
-        $this->assertEquals(36, strlen($id1));
-        $this->assertEquals(36, strlen($id2));
+        $this->assertSame(36, strlen($id1));
+        $this->assertSame(36, strlen($id2));
     }
 
     /**

--- a/src/Opulence/Orm/Tests/Repositories/RepositoryTest.php
+++ b/src/Opulence/Orm/Tests/Repositories/RepositoryTest.php
@@ -160,7 +160,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
         foreach ($allEntities as $entity) {
             if ($entity->getId() == $entityFromGetById->getId()) {
                 $this->assertSame($entityFromGetById, $entity);
-                $this->assertEquals($entityFromGetAll->getUsername(), $entityFromGetById->getUsername());
+                $this->assertSame($entityFromGetAll->getUsername(), $entityFromGetById->getUsername());
             }
         }
     }

--- a/src/Opulence/Orm/Tests/UnitOfWorkTest.php
+++ b/src/Opulence/Orm/Tests/UnitOfWorkTest.php
@@ -104,7 +104,7 @@ class UnitOfWorkTest extends \PHPUnit\Framework\TestCase
         $method->invoke($this->unitOfWork);
         $scheduledFoUpdate = $this->unitOfWork->getScheduledEntityUpdates();
         $this->unitOfWork->commit();
-        $this->assertTrue(in_array($this->entity1, $scheduledFoUpdate));
+        $this->assertContains($this->entity1, $scheduledFoUpdate);
     }
 
     /**
@@ -141,10 +141,10 @@ class UnitOfWorkTest extends \PHPUnit\Framework\TestCase
         $this->unitOfWork->scheduleForUpdate($this->entity1);
         $this->unitOfWork->detach($this->entity1);
         $this->assertFalse($this->entityRegistry->isRegistered($this->entity1));
-        $this->assertEquals(EntityStates::UNREGISTERED, $this->entityRegistry->getEntityState($this->entity1));
-        $this->assertFalse(in_array($this->entity1, $this->unitOfWork->getScheduledEntityDeletions()));
-        $this->assertFalse(in_array($this->entity1, $this->unitOfWork->getScheduledEntityInsertions()));
-        $this->assertFalse(in_array($this->entity1, $this->unitOfWork->getScheduledEntityUpdates()));
+        $this->assertSame(EntityStates::UNREGISTERED, $this->entityRegistry->getEntityState($this->entity1));
+        $this->assertNotContains($this->entity1, $this->unitOfWork->getScheduledEntityDeletions());
+        $this->assertNotContains($this->entity1, $this->unitOfWork->getScheduledEntityInsertions());
+        $this->assertNotContains($this->entity1, $this->unitOfWork->getScheduledEntityUpdates());
     }
 
     /**
@@ -155,7 +155,7 @@ class UnitOfWorkTest extends \PHPUnit\Framework\TestCase
         $this->entityRegistry->registerEntity($this->entity1);
         $this->unitOfWork->dispose();
         $this->assertFalse($this->entityRegistry->isRegistered($this->entity1));
-        $this->assertEquals(EntityStates::NEVER_REGISTERED, $this->entityRegistry->getEntityState($this->entity1));
+        $this->assertSame(EntityStates::NEVER_REGISTERED, $this->entityRegistry->getEntityState($this->entity1));
         $this->assertEquals([], $this->unitOfWork->getScheduledEntityDeletions());
         $this->assertEquals([], $this->unitOfWork->getScheduledEntityInsertions());
         $this->assertEquals([], $this->unitOfWork->getScheduledEntityUpdates());
@@ -274,7 +274,7 @@ class UnitOfWorkTest extends \PHPUnit\Framework\TestCase
         $this->unitOfWork->scheduleForDeletion($this->entity1);
         $this->unitOfWork->commit();
         $this->assertFalse($this->entityRegistry->isRegistered($this->entity1));
-        $this->assertEquals(EntityStates::DEQUEUED, $this->entityRegistry->getEntityState($this->entity1));
+        $this->assertSame(EntityStates::DEQUEUED, $this->entityRegistry->getEntityState($this->entity1));
         $this->expectException(OrmException::class);
         $this->dataMapper->getById($this->entity1->getId());
     }
@@ -292,7 +292,7 @@ class UnitOfWorkTest extends \PHPUnit\Framework\TestCase
         $method->setAccessible(true);
         $method->invoke($this->unitOfWork);
         $scheduledFoUpdate = $this->unitOfWork->getScheduledEntityUpdates();
-        $this->assertFalse(in_array($this->entity1, $scheduledFoUpdate));
+        $this->assertNotContains($this->entity1, $scheduledFoUpdate);
     }
 
     /**
@@ -344,9 +344,9 @@ class UnitOfWorkTest extends \PHPUnit\Framework\TestCase
         $method->invoke($this->unitOfWork);
         $scheduledFoDeletion = $this->unitOfWork->getScheduledEntityDeletions();
         $this->unitOfWork->commit();
-        $this->assertTrue(in_array($this->entity1, $scheduledFoDeletion));
+        $this->assertContains($this->entity1, $scheduledFoDeletion);
         $this->assertFalse($this->entityRegistry->isRegistered($this->entity1));
-        $this->assertEquals(EntityStates::DEQUEUED, $this->entityRegistry->getEntityState($this->entity1));
+        $this->assertSame(EntityStates::DEQUEUED, $this->entityRegistry->getEntityState($this->entity1));
         $this->expectException(OrmException::class);
         $this->dataMapper->getById($this->entity1->getId());
     }
@@ -359,7 +359,7 @@ class UnitOfWorkTest extends \PHPUnit\Framework\TestCase
         $className = $this->entityRegistry->getClassName($this->entity1);
         $this->unitOfWork->registerDataMapper($className, $this->dataMapper);
         $this->unitOfWork->scheduleForInsertion($this->entity1);
-        $this->assertEquals(EntityStates::QUEUED, $this->entityRegistry->getEntityState($this->entity1));
+        $this->assertSame(EntityStates::QUEUED, $this->entityRegistry->getEntityState($this->entity1));
         $reflectionClass = new \ReflectionClass($this->unitOfWork);
         $method = $reflectionClass->getMethod('checkForUpdates');
         $method->setAccessible(true);
@@ -367,11 +367,11 @@ class UnitOfWorkTest extends \PHPUnit\Framework\TestCase
         $scheduledFoInsertion = $this->unitOfWork->getScheduledEntityInsertions();
         $expectedId = $this->dataMapper->getCurrId() + 1;
         $this->unitOfWork->commit();
-        $this->assertTrue(in_array($this->entity1, $scheduledFoInsertion));
+        $this->assertContains($this->entity1, $scheduledFoInsertion);
         $this->assertEquals($this->entity1, $this->entityRegistry->getEntity($className, $this->entity1->getId()));
-        $this->assertEquals(EntityStates::REGISTERED, $this->entityRegistry->getEntityState($this->entity1));
+        $this->assertSame(EntityStates::REGISTERED, $this->entityRegistry->getEntityState($this->entity1));
         $this->assertEquals($this->entity1, $this->dataMapper->getById($this->entity1->getId()));
-        $this->assertEquals($expectedId, $this->entity1->getId());
+        $this->assertSame($expectedId, $this->entity1->getId());
     }
 
     /**
@@ -389,9 +389,9 @@ class UnitOfWorkTest extends \PHPUnit\Framework\TestCase
         $method->invoke($this->unitOfWork);
         $scheduledFoUpdate = $this->unitOfWork->getScheduledEntityUpdates();
         $this->unitOfWork->commit();
-        $this->assertTrue(in_array($this->entity1, $scheduledFoUpdate));
+        $this->assertContains($this->entity1, $scheduledFoUpdate);
         $this->assertEquals($this->entity1, $this->entityRegistry->getEntity($className, $this->entity1->getId()));
-        $this->assertEquals(EntityStates::REGISTERED, $this->entityRegistry->getEntityState($this->entity1));
+        $this->assertSame(EntityStates::REGISTERED, $this->entityRegistry->getEntityState($this->entity1));
         $this->assertEquals($this->entity1, $this->dataMapper->getById($this->entity1->getId()));
     }
 
@@ -413,7 +413,7 @@ class UnitOfWorkTest extends \PHPUnit\Framework\TestCase
             });
         $this->unitOfWork->commit();
         $this->assertNotEquals($originalAggregateRootId, $this->entity2->getAggregateRootId());
-        $this->assertEquals($this->entity1->getId(), $this->entity2->getAggregateRootId());
+        $this->assertSame($this->entity1->getId(), $this->entity2->getAggregateRootId());
     }
 
     /**
@@ -434,7 +434,7 @@ class UnitOfWorkTest extends \PHPUnit\Framework\TestCase
             });
         $this->unitOfWork->commit();
         $this->assertNotEquals($originalAggregateRootId, $this->entity2->getAggregateRootId());
-        $this->assertEquals($this->entity1->getId(), $this->entity2->getAggregateRootId());
+        $this->assertSame($this->entity1->getId(), $this->entity2->getAggregateRootId());
     }
 
     /**
@@ -443,7 +443,7 @@ class UnitOfWorkTest extends \PHPUnit\Framework\TestCase
     public function testThatEntityIdIsBeingSetAfterCommit()
     {
         $foo = $this->getInsertedEntity();
-        $this->assertEquals(1, $foo->getId());
+        $this->assertSame(1, $foo->getId());
     }
 
     /**

--- a/src/Opulence/Pipelines/Tests/PipelineTest.php
+++ b/src/Opulence/Pipelines/Tests/PipelineTest.php
@@ -50,7 +50,7 @@ class PipelineTest extends \PHPUnit\Framework\TestCase
         $this->pipeline->send('input')
             ->through($stages)
             ->then($callback);
-        $this->assertEquals('input123', $this->pipeline->execute());
+        $this->assertSame('input123', $this->pipeline->execute());
     }
 
     /**
@@ -79,7 +79,7 @@ class PipelineTest extends \PHPUnit\Framework\TestCase
         ];
         $this->pipeline->send('input')
             ->through($stages);
-        $this->assertEquals('input12', $this->pipeline->execute());
+        $this->assertSame('input12', $this->pipeline->execute());
     }
 
     /**
@@ -90,7 +90,7 @@ class PipelineTest extends \PHPUnit\Framework\TestCase
         $stages = [new Stage1(), new Stage2()];
         $this->pipeline->send('input')
             ->through($stages, 'run');
-        $this->assertEquals('input12', $this->pipeline->execute());
+        $this->assertSame('input12', $this->pipeline->execute());
     }
 
     /**
@@ -117,7 +117,7 @@ class PipelineTest extends \PHPUnit\Framework\TestCase
         $this->pipeline->send('input')
             ->through($stages, 'run')
             ->then($callback);
-        $this->assertEquals('input123', $this->pipeline->execute());
+        $this->assertSame('input123', $this->pipeline->execute());
     }
 
     /**
@@ -132,7 +132,7 @@ class PipelineTest extends \PHPUnit\Framework\TestCase
         ];
         $this->pipeline->send('input')
             ->through($stages);
-        $this->assertEquals('input1', $this->pipeline->execute());
+        $this->assertSame('input1', $this->pipeline->execute());
     }
 
     /**
@@ -143,7 +143,7 @@ class PipelineTest extends \PHPUnit\Framework\TestCase
         $stages = [new Stage1()];
         $this->pipeline->send('input')
             ->through($stages, 'run');
-        $this->assertEquals('input1', $this->pipeline->execute());
+        $this->assertSame('input1', $this->pipeline->execute());
     }
 
     /**
@@ -161,7 +161,7 @@ class PipelineTest extends \PHPUnit\Framework\TestCase
         ];
         $this->pipeline->send('input')
             ->through($stages);
-        $this->assertEquals('input1', $this->pipeline->execute());
+        $this->assertSame('input1', $this->pipeline->execute());
     }
 
     /**
@@ -183,7 +183,7 @@ class PipelineTest extends \PHPUnit\Framework\TestCase
         $this->pipeline->send('input')
             ->through($stages, 'run')
             ->then($callback);
-        $this->assertEquals('input1', $this->pipeline->execute());
+        $this->assertSame('input1', $this->pipeline->execute());
     }
 
     /**
@@ -199,6 +199,6 @@ class PipelineTest extends \PHPUnit\Framework\TestCase
         ];
         $this->pipeline->send('input')
             ->through($stages, 'run');
-        $this->assertEquals('input32', $this->pipeline->execute());
+        $this->assertSame('input32', $this->pipeline->execute());
     }
 }

--- a/src/Opulence/QueryBuilders/Tests/ConditionalQueryBuilderTest.php
+++ b/src/Opulence/QueryBuilders/Tests/ConditionalQueryBuilderTest.php
@@ -62,7 +62,7 @@ class ConditionalQueryBuilderTest extends \PHPUnit\Framework\TestCase
         $queryBuilder->where("name = 'dave'")
             ->orWhere("email = 'foo@bar.com'")
             ->andWhere('awesome = true');
-        $this->assertEquals(" WHERE (name = 'dave') OR (email = 'foo@bar.com') AND (awesome = true)",
+        $this->assertSame(" WHERE (name = 'dave') OR (email = 'foo@bar.com') AND (awesome = true)",
             $queryBuilder->getClauseConditionSql('WHERE', $queryBuilder->getWhereConditions()));
     }
 

--- a/src/Opulence/QueryBuilders/Tests/Conditions/BetweenConditionTest.php
+++ b/src/Opulence/QueryBuilders/Tests/Conditions/BetweenConditionTest.php
@@ -48,6 +48,6 @@ class BetweenConditionTest extends \PHPUnit\Framework\TestCase
     public function testGettingSql()
     {
         $condition = new BetweenCondition('foo', 1, 2);
-        $this->assertEquals('foo BETWEEN ? AND ?', $condition->getSql());
+        $this->assertSame('foo BETWEEN ? AND ?', $condition->getSql());
     }
 }

--- a/src/Opulence/QueryBuilders/Tests/Conditions/InConditionTest.php
+++ b/src/Opulence/QueryBuilders/Tests/Conditions/InConditionTest.php
@@ -46,7 +46,7 @@ class InConditionTest extends \PHPUnit\Framework\TestCase
     public function testGettingSqlForInConditionWithParameters()
     {
         $condition = new InCondition('foo', [[1, PDO::PARAM_INT], [2, PDO::PARAM_INT], [3, PDO::PARAM_INT]]);
-        $this->assertEquals('foo IN (?,?,?)', $condition->getSql());
+        $this->assertSame('foo IN (?,?,?)', $condition->getSql());
     }
 
     /**
@@ -55,7 +55,7 @@ class InConditionTest extends \PHPUnit\Framework\TestCase
     public function testGettingSqlForInConditionWithSubExpression()
     {
         $condition = new InCondition('foo', 'SELECT bar FROM baz');
-        $this->assertEquals('foo IN (SELECT bar FROM baz)', $condition->getSql());
+        $this->assertSame('foo IN (SELECT bar FROM baz)', $condition->getSql());
     }
 
     /**

--- a/src/Opulence/QueryBuilders/Tests/Conditions/NotBetweenConditionTest.php
+++ b/src/Opulence/QueryBuilders/Tests/Conditions/NotBetweenConditionTest.php
@@ -23,6 +23,6 @@ class NotBetweenConditionTest extends \PHPUnit\Framework\TestCase
     public function testGettingSql()
     {
         $condition = new NotBetweenCondition('foo', 1, 2);
-        $this->assertEquals('foo NOT BETWEEN ? AND ?', $condition->getSql());
+        $this->assertSame('foo NOT BETWEEN ? AND ?', $condition->getSql());
     }
 }

--- a/src/Opulence/QueryBuilders/Tests/Conditions/NotInConditionTest.php
+++ b/src/Opulence/QueryBuilders/Tests/Conditions/NotInConditionTest.php
@@ -24,7 +24,7 @@ class NotInConditionTest extends \PHPUnit\Framework\TestCase
     public function testGettingSqlForNotInConditionWithParameters()
     {
         $condition = new NotInCondition('foo', [[1, PDO::PARAM_INT], [2, PDO::PARAM_INT], [3, PDO::PARAM_INT]]);
-        $this->assertEquals('foo NOT IN (?,?,?)', $condition->getSql());
+        $this->assertSame('foo NOT IN (?,?,?)', $condition->getSql());
     }
 
     /**
@@ -33,6 +33,6 @@ class NotInConditionTest extends \PHPUnit\Framework\TestCase
     public function testGettingSqlForNotInConditionWithSubExpression()
     {
         $condition = new NotInCondition('foo', 'SELECT bar FROM baz');
-        $this->assertEquals('foo NOT IN (SELECT bar FROM baz)', $condition->getSql());
+        $this->assertSame('foo NOT IN (SELECT bar FROM baz)', $condition->getSql());
     }
 }

--- a/src/Opulence/QueryBuilders/Tests/DeleteQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/DeleteQueryTest.php
@@ -46,7 +46,7 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
             ->addUsing('subscriptions')
             ->where("users.id = emails.userid AND emails.email = 'foo@bar.com'")
             ->orWhere("subscriptions.userid = users.id AND subscriptions.type = 'customer'");
-        $this->assertEquals("DELETE FROM users USING emails, subscriptions WHERE (users.id = emails.userid AND emails.email = 'foo@bar.com') OR (subscriptions.userid = users.id AND subscriptions.type = 'customer')",
+        $this->assertSame("DELETE FROM users USING emails, subscriptions WHERE (users.id = emails.userid AND emails.email = 'foo@bar.com') OR (subscriptions.userid = users.id AND subscriptions.type = 'customer')",
             $query->getSql());
     }
 
@@ -58,7 +58,7 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
         $query = new DeleteQuery('users');
         $query->where('id = 1')
             ->andWhere("name = 'dave'");
-        $this->assertEquals("DELETE FROM users WHERE (id = 1) AND (name = 'dave')", $query->getSql());
+        $this->assertSame("DELETE FROM users WHERE (id = 1) AND (name = 'dave')", $query->getSql());
     }
 
     /**
@@ -69,7 +69,7 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
         $query = new DeleteQuery('users');
         $query->where('id = 1')
             ->andWhere($this->condition);
-        $this->assertEquals('DELETE FROM users WHERE (id = 1) AND (c1 IN (?))', $query->getSql());
+        $this->assertSame('DELETE FROM users WHERE (id = 1) AND (c1 IN (?))', $query->getSql());
         $this->assertEquals([[1, PDO::PARAM_INT]], $query->getParameters());
     }
 
@@ -79,7 +79,7 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
     public function testBasicQuery()
     {
         $query = new DeleteQuery('users');
-        $this->assertEquals('DELETE FROM users', $query->getSql());
+        $this->assertSame('DELETE FROM users', $query->getSql());
     }
 
     /**
@@ -94,7 +94,7 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
             ->orWhere('u.name = :name')
             ->andWhere('subscriptions.userid = u.id', "subscriptions.type = 'customer'")
             ->addNamedPlaceholderValues(['userId' => 18175, 'email' => 'foo@bar.com', 'name' => 'dave']);
-        $this->assertEquals("DELETE FROM users AS u USING emails, subscriptions WHERE (u.id = :userId) AND (emails.userid = u.id) AND (emails.email = :email) OR (u.name = :name) AND (subscriptions.userid = u.id) AND (subscriptions.type = 'customer')",
+        $this->assertSame("DELETE FROM users AS u USING emails, subscriptions WHERE (u.id = :userId) AND (emails.userid = u.id) AND (emails.email = :email) OR (u.name = :name) AND (subscriptions.userid = u.id) AND (subscriptions.type = 'customer')",
             $query->getSql());
     }
 
@@ -106,7 +106,7 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
         $query = new DeleteQuery('users');
         $query->where('id = 1')
             ->orWhere("name = 'dave'");
-        $this->assertEquals("DELETE FROM users WHERE (id = 1) OR (name = 'dave')", $query->getSql());
+        $this->assertSame("DELETE FROM users WHERE (id = 1) OR (name = 'dave')", $query->getSql());
     }
 
     /**
@@ -117,7 +117,7 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
         $query = new DeleteQuery('users');
         $query->where('id = 1')
             ->orWhere($this->condition);
-        $this->assertEquals('DELETE FROM users WHERE (id = 1) OR (c1 IN (?))', $query->getSql());
+        $this->assertSame('DELETE FROM users WHERE (id = 1) OR (c1 IN (?))', $query->getSql());
         $this->assertEquals([[1, PDO::PARAM_INT]], $query->getParameters());
     }
 
@@ -127,7 +127,7 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
     public function testTableAlias()
     {
         $query = new DeleteQuery('users', 'u');
-        $this->assertEquals('DELETE FROM users AS u', $query->getSql());
+        $this->assertSame('DELETE FROM users AS u', $query->getSql());
     }
 
     /**
@@ -138,7 +138,7 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
         $query = new DeleteQuery('users');
         $query->using('emails')
             ->where("users.id = emails.userid AND emails.email = 'foo@bar.com'");
-        $this->assertEquals("DELETE FROM users USING emails WHERE (users.id = emails.userid AND emails.email = 'foo@bar.com')",
+        $this->assertSame("DELETE FROM users USING emails WHERE (users.id = emails.userid AND emails.email = 'foo@bar.com')",
             $query->getSql());
     }
 
@@ -149,7 +149,7 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
     {
         $query = new DeleteQuery('users');
         $query->where('id = 1');
-        $this->assertEquals('DELETE FROM users WHERE (id = 1)', $query->getSql());
+        $this->assertSame('DELETE FROM users WHERE (id = 1)', $query->getSql());
     }
 
     /**
@@ -159,7 +159,7 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
     {
         $query = new DeleteQuery('users');
         $query->where($this->condition);
-        $this->assertEquals('DELETE FROM users WHERE (c1 IN (?))', $query->getSql());
+        $this->assertSame('DELETE FROM users WHERE (c1 IN (?))', $query->getSql());
         $this->assertEquals([[1, PDO::PARAM_INT]], $query->getParameters());
     }
 }

--- a/src/Opulence/QueryBuilders/Tests/InsertQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/InsertQueryTest.php
@@ -25,7 +25,7 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
     {
         $query = new InsertQuery('users', ['name' => 'dave']);
         $query->addColumnValues(['email' => 'foo@bar.com']);
-        $this->assertEquals('INSERT INTO users (name, email) VALUES (?, ?)', $query->getSql());
+        $this->assertSame('INSERT INTO users (name, email) VALUES (?, ?)', $query->getSql());
         $this->assertEquals([
             ['dave', \PDO::PARAM_STR],
             ['foo@bar.com', \PDO::PARAM_STR],
@@ -38,7 +38,7 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
     public function testBasicQuery()
     {
         $query = new InsertQuery('users', ['name' => 'dave', 'email' => 'foo@bar.com']);
-        $this->assertEquals('INSERT INTO users (name, email) VALUES (?, ?)', $query->getSql());
+        $this->assertSame('INSERT INTO users (name, email) VALUES (?, ?)', $query->getSql());
         $this->assertEquals([
             ['dave', \PDO::PARAM_STR],
             ['foo@bar.com', \PDO::PARAM_STR]
@@ -52,7 +52,7 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
     {
         $query = new InsertQuery('users',
             ['name' => 'dave', 'email' => 'foo@bar.com', 'valid_until' => new Expression('NOW()')]);
-        $this->assertEquals('INSERT INTO users (name, email, valid_until) VALUES (?, ?, NOW())', $query->getSql());
+        $this->assertSame('INSERT INTO users (name, email, valid_until) VALUES (?, ?, NOW())', $query->getSql());
         $this->assertEquals([
             ['dave', \PDO::PARAM_STR],
             ['foo@bar.com', \PDO::PARAM_STR],
@@ -70,7 +70,7 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
                 'email' => 'foo@bar.com',
                 'is_val_even' => new Expression('(val + ?) % ?', ['1', \PDO::PARAM_INT], [2, \PDO::PARAM_INT])
             ]);
-        $this->assertEquals('INSERT INTO users (name, email, is_val_even) VALUES (?, ?, (val + ?) % ?)',
+        $this->assertSame('INSERT INTO users (name, email, is_val_even) VALUES (?, ?, (val + ?) % ?)',
             $query->getSql());
         $this->assertSame([
             ['dave', \PDO::PARAM_STR],
@@ -89,7 +89,7 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
         $query = new InsertQuery('users', ['name' => 'dave']);
         $query->addColumnValues(['email' => 'foo@bar.com', 'is_val_even' => $expr])
             ->addUnnamedPlaceholderValues([[2, \PDO::PARAM_INT]]);
-        $this->assertEquals('INSERT INTO users (name, email, is_val_even) VALUES (?, ?, (val + ?) % ?)', $query->getSql());
+        $this->assertSame('INSERT INTO users (name, email, is_val_even) VALUES (?, ?, (val + ?) % ?)', $query->getSql());
         $this->assertSame([
             ['dave', \PDO::PARAM_STR],
             ['foo@bar.com', \PDO::PARAM_STR],

--- a/src/Opulence/QueryBuilders/Tests/MySql/DeleteQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/MySql/DeleteQueryTest.php
@@ -30,7 +30,7 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
             ->addNamedPlaceholderValues(['userId' => [18175, PDO::PARAM_INT]])
             ->addNamedPlaceholderValue('name', 'dave')
             ->limit(1);
-        $this->assertEquals('DELETE FROM users AS u WHERE (u.id = :userId) AND (u.name = :name) OR (u.id = 10) LIMIT 1',
+        $this->assertSame('DELETE FROM users AS u WHERE (u.id = :userId) AND (u.name = :name) OR (u.id = 10) LIMIT 1',
             $query->getSql());
         $this->assertEquals([
             'userId' => [18175, PDO::PARAM_INT],
@@ -45,7 +45,7 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
     {
         $query = new DeleteQuery('users');
         $query->limit(1);
-        $this->assertEquals('DELETE FROM users LIMIT 1', $query->getSql());
+        $this->assertSame('DELETE FROM users LIMIT 1', $query->getSql());
     }
 
     /**
@@ -55,6 +55,6 @@ class DeleteQueryTest extends \PHPUnit\Framework\TestCase
     {
         $query = new DeleteQuery('users');
         $query->limit(':limit');
-        $this->assertEquals('DELETE FROM users LIMIT :limit', $query->getSql());
+        $this->assertSame('DELETE FROM users LIMIT :limit', $query->getSql());
     }
 }

--- a/src/Opulence/QueryBuilders/Tests/MySql/InsertQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/MySql/InsertQueryTest.php
@@ -27,7 +27,7 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
         $query = new InsertQuery('users', ['name' => 'dave', 'email' => 'foo@bar.com']);
         $query->update(['name' => 'dave'])
             ->addUpdateColumnValues(['email' => 'foo@bar.com']);
-        $this->assertEquals('INSERT INTO users (name, email) VALUES (?, ?) ON DUPLICATE KEY UPDATE name = ?, email = ?',
+        $this->assertSame('INSERT INTO users (name, email) VALUES (?, ?) ON DUPLICATE KEY UPDATE name = ?, email = ?',
             $query->getSql());
         $this->assertEquals([
             ['dave', PDO::PARAM_STR],
@@ -41,7 +41,7 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
     public function testBasicQuery()
     {
         $query = new InsertQuery('users', ['name' => 'dave', 'email' => 'foo@bar.com']);
-        $this->assertEquals('INSERT INTO users (name, email) VALUES (?, ?)', $query->getSql());
+        $this->assertSame('INSERT INTO users (name, email) VALUES (?, ?)', $query->getSql());
         $this->assertEquals([
             ['dave', PDO::PARAM_STR],
             ['foo@bar.com', PDO::PARAM_STR]
@@ -61,7 +61,7 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
             ]);
         $query->update(['name' => 'dave'])
             ->addUpdateColumnValues(['email' => 'foo@bar.com']);
-        $this->assertEquals('INSERT INTO users (name, email, is_val_even) VALUES (?, ?, (val + ?) % ?) ON DUPLICATE KEY UPDATE name = ?, email = ?',
+        $this->assertSame('INSERT INTO users (name, email, is_val_even) VALUES (?, ?, (val + ?) % ?) ON DUPLICATE KEY UPDATE name = ?, email = ?',
             $query->getSql());
         $this->assertSame([
             ['dave', PDO::PARAM_STR],
@@ -78,7 +78,7 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
     {
         $query = new InsertQuery('users', ['name' => 'dave', 'email' => 'foo@bar.com']);
         $query->update(['name' => 'dave', 'email' => 'foo@bar.com']);
-        $this->assertEquals('INSERT INTO users (name, email) VALUES (?, ?) ON DUPLICATE KEY UPDATE name = ?, email = ?',
+        $this->assertSame('INSERT INTO users (name, email) VALUES (?, ?) ON DUPLICATE KEY UPDATE name = ?, email = ?',
             $query->getSql());
         $this->assertEquals([
             ['dave', PDO::PARAM_STR],

--- a/src/Opulence/QueryBuilders/Tests/PostgreSql/AugmentingQueryBuilderTest.php
+++ b/src/Opulence/QueryBuilders/Tests/PostgreSql/AugmentingQueryBuilderTest.php
@@ -25,7 +25,7 @@ class AugmentingQueryBuilderTest extends \PHPUnit\Framework\TestCase
         $queryBuilder = new AugmentingQueryBuilder();
         $queryBuilder->returning('id')
             ->addReturning('name');
-        $this->assertEquals(' RETURNING id, name', $queryBuilder->getReturningClauseSql());
+        $this->assertSame(' RETURNING id, name', $queryBuilder->getReturningClauseSql());
     }
 
     /**
@@ -35,6 +35,6 @@ class AugmentingQueryBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $queryBuilder = new AugmentingQueryBuilder();
         $queryBuilder->returning('id');
-        $this->assertEquals(' RETURNING id', $queryBuilder->getReturningClauseSql());
+        $this->assertSame(' RETURNING id', $queryBuilder->getReturningClauseSql());
     }
 }

--- a/src/Opulence/QueryBuilders/Tests/PostgreSql/InsertQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/PostgreSql/InsertQueryTest.php
@@ -27,7 +27,7 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
         $query = new InsertQuery('users', ['name' => 'dave']);
         $query->returning('id')
             ->addReturning('name');
-        $this->assertEquals('INSERT INTO users (name) VALUES (?) RETURNING id, name', $query->getSql());
+        $this->assertSame('INSERT INTO users (name) VALUES (?) RETURNING id, name', $query->getSql());
         $this->assertEquals([
             ['dave', PDO::PARAM_STR]
         ], $query->getParameters());
@@ -44,7 +44,7 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
             ->returning('id')
             ->addReturning('name')
             ->addUnnamedPlaceholderValues([[2, \PDO::PARAM_INT]]);
-        $this->assertEquals('INSERT INTO users (name, email, is_val_even) VALUES (?, ?, (val + ?) % ?) RETURNING id, name',
+        $this->assertSame('INSERT INTO users (name, email, is_val_even) VALUES (?, ?, (val + ?) % ?) RETURNING id, name',
             $query->getSql());
         $this->assertSame([
             ['dave', PDO::PARAM_STR],
@@ -61,7 +61,7 @@ class InsertQueryTest extends \PHPUnit\Framework\TestCase
     {
         $query = new InsertQuery('users', ['name' => 'dave']);
         $query->returning('id', 'name');
-        $this->assertEquals('INSERT INTO users (name) VALUES (?) RETURNING id, name', $query->getSql());
+        $this->assertSame('INSERT INTO users (name) VALUES (?) RETURNING id, name', $query->getSql());
         $this->assertEquals([
             ['dave', PDO::PARAM_STR]
         ], $query->getParameters());

--- a/src/Opulence/QueryBuilders/Tests/PostgreSql/UpdateQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/PostgreSql/UpdateQueryTest.php
@@ -27,7 +27,7 @@ class UpdateQueryTest extends \PHPUnit\Framework\TestCase
         $query = new UpdateQuery('users', '', ['name' => 'david']);
         $query->returning('id')
             ->addReturning('name');
-        $this->assertEquals('UPDATE users SET name = ? RETURNING id, name', $query->getSql());
+        $this->assertSame('UPDATE users SET name = ? RETURNING id, name', $query->getSql());
         $this->assertEquals([
             ['david', PDO::PARAM_STR]
         ], $query->getParameters());
@@ -47,7 +47,7 @@ class UpdateQueryTest extends \PHPUnit\Framework\TestCase
             ->returning('u.id')
             ->addReturning('u.name')
             ->addUnnamedPlaceholderValues([[2, PDO::PARAM_INT], [18175, PDO::PARAM_INT], 'foo@bar.com', 'dave']);
-        $this->assertEquals("UPDATE users AS u SET name = ?, email = ?, is_val_even = (val + ?) % ? WHERE (u.id = ?) AND (emails.userid = u.id) AND (emails.email = ?) OR (u.name = ?) AND (subscriptions.userid = u.id) AND (subscriptions.type = 'customer') RETURNING u.id, u.name",
+        $this->assertSame("UPDATE users AS u SET name = ?, email = ?, is_val_even = (val + ?) % ? WHERE (u.id = ?) AND (emails.userid = u.id) AND (emails.email = ?) OR (u.name = ?) AND (subscriptions.userid = u.id) AND (subscriptions.type = 'customer') RETURNING u.id, u.name",
             $query->getSql());
         $this->assertEquals([
             ['david', PDO::PARAM_STR],
@@ -67,7 +67,7 @@ class UpdateQueryTest extends \PHPUnit\Framework\TestCase
     {
         $query = new UpdateQuery('users', '', ['name' => 'david']);
         $query->returning('id');
-        $this->assertEquals('UPDATE users SET name = ? RETURNING id', $query->getSql());
+        $this->assertSame('UPDATE users SET name = ? RETURNING id', $query->getSql());
         $this->assertEquals([
             ['david', PDO::PARAM_STR]
         ], $query->getParameters());

--- a/src/Opulence/QueryBuilders/Tests/QueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/QueryTest.php
@@ -121,7 +121,7 @@ class QueryTest extends \PHPUnit\Framework\TestCase
         $this->query = $this->getMockForAbstractClass(Query::class);
         $this->query->addNamedPlaceholderValue($key, 'bar');
         $this->query->removeNamedPlaceHolder($key);
-        $this->assertFalse(array_key_exists($key, $this->query->getParameters()));
+        $this->assertArrayNotHasKey($key, $this->query->getParameters());
     }
 
     /**

--- a/src/Opulence/QueryBuilders/Tests/SelectQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/SelectQueryTest.php
@@ -45,7 +45,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query->from('users')
             ->groupBy('id')
             ->addGroupBy('name');
-        $this->assertEquals('SELECT id, name FROM users GROUP BY id, name', $query->getSql());
+        $this->assertSame('SELECT id, name FROM users GROUP BY id, name', $query->getSql());
     }
 
     /**
@@ -58,7 +58,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
             ->where('id > 10')
             ->orWhere("name <> 'dave'")
             ->andWhere("name <> 'brian'");
-        $this->assertEquals("SELECT id FROM users WHERE (id > 10) OR (name <> 'dave') AND (name <> 'brian')",
+        $this->assertSame("SELECT id FROM users WHERE (id > 10) OR (name <> 'dave') AND (name <> 'brian')",
             $query->getSql());
     }
 
@@ -71,7 +71,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query->from('users')
             ->orderBy('id ASC')
             ->addOrderBy('name DESC');
-        $this->assertEquals('SELECT id, name FROM users ORDER BY id ASC, name DESC', $query->getSql());
+        $this->assertSame('SELECT id, name FROM users ORDER BY id ASC, name DESC', $query->getSql());
     }
 
     public function testAddingSelectExpression()
@@ -79,7 +79,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query = new SelectQuery('id');
         $query->from('users')
             ->addSelectExpression('name');
-        $this->assertEquals('SELECT id, name FROM users', $query->getSql());
+        $this->assertSame('SELECT id, name FROM users', $query->getSql());
     }
 
     /**
@@ -92,7 +92,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
             ->groupBy('name')
             ->having('COUNT(name) > 1')
             ->andHaving('COUNT(name) < 5');
-        $this->assertEquals('SELECT name FROM users GROUP BY name HAVING (COUNT(name) > 1) AND (COUNT(name) < 5)',
+        $this->assertSame('SELECT name FROM users GROUP BY name HAVING (COUNT(name) > 1) AND (COUNT(name) < 5)',
             $query->getSql());
     }
 
@@ -106,7 +106,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
             ->groupBy('name')
             ->having('COUNT(name) > 1')
             ->andHaving($this->condition);
-        $this->assertEquals('SELECT name FROM users GROUP BY name HAVING (COUNT(name) > 1) AND (c1 IN (?))',
+        $this->assertSame('SELECT name FROM users GROUP BY name HAVING (COUNT(name) > 1) AND (c1 IN (?))',
             $query->getSql());
         $this->assertEquals([[1, PDO::PARAM_INT]], $query->getParameters());
     }
@@ -120,7 +120,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query->from('users')
             ->where('id > 10')
             ->andWhere("name <> 'dave'");
-        $this->assertEquals("SELECT id FROM users WHERE (id > 10) AND (name <> 'dave')", $query->getSql());
+        $this->assertSame("SELECT id FROM users WHERE (id > 10) AND (name <> 'dave')", $query->getSql());
     }
 
     /**
@@ -132,7 +132,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query->from('users')
             ->where('id > 10')
             ->andWhere($this->condition);
-        $this->assertEquals('SELECT id FROM users WHERE (id > 10) AND (c1 IN (?))', $query->getSql());
+        $this->assertSame('SELECT id FROM users WHERE (id > 10) AND (c1 IN (?))', $query->getSql());
         $this->assertEquals([[1, PDO::PARAM_INT]], $query->getParameters());
     }
 
@@ -143,7 +143,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
     {
         $query = new SelectQuery('id', 'name');
         $query->from('users');
-        $this->assertEquals('SELECT id, name FROM users', $query->getSql());
+        $this->assertSame('SELECT id, name FROM users', $query->getSql());
     }
 
     /**
@@ -153,7 +153,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
     {
         $query = new SelectQuery('u.id', 'u.name');
         $query->from('users', 'u');
-        $this->assertEquals('SELECT u.id, u.name FROM users AS u', $query->getSql());
+        $this->assertSame('SELECT u.id, u.name FROM users AS u', $query->getSql());
     }
 
     /**
@@ -181,7 +181,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
             ->addOrderBy('u.name ASC')
             ->limit(2)
             ->offset(1);
-        $this->assertEquals('SELECT u.id, u.name, e.email, CHARACTER_LENGTH(e.email) AS email_length, p.password FROM users AS u INNER JOIN log AS l ON l.userid = u.id LEFT JOIN emails AS e ON e.userid = u.id RIGHT JOIN password AS p ON p.userid = u.id WHERE (u.id <> 10) AND (u.name <> :notAllowedName) AND (u.id <> 9) OR (u.name = :allowedName) GROUP BY u.id, u.name, e.email, p.password HAVING (count(*) > :minCount) AND (count(*) < 5) OR (count(*) = 2) ORDER BY u.id DESC, u.name ASC LIMIT 2 OFFSET 1',
+        $this->assertSame('SELECT u.id, u.name, e.email, CHARACTER_LENGTH(e.email) AS email_length, p.password FROM users AS u INNER JOIN log AS l ON l.userid = u.id LEFT JOIN emails AS e ON e.userid = u.id RIGHT JOIN password AS p ON p.userid = u.id WHERE (u.id <> 10) AND (u.name <> :notAllowedName) AND (u.id <> 9) OR (u.name = :allowedName) GROUP BY u.id, u.name, e.email, p.password HAVING (count(*) > :minCount) AND (count(*) < 5) OR (count(*) = 2) ORDER BY u.id DESC, u.name ASC LIMIT 2 OFFSET 1',
             $query->getSql());
         $this->assertEquals([
             'notAllowedName' => ['dave', PDO::PARAM_STR],
@@ -198,7 +198,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query = new SelectQuery('id', 'name');
         $query->from('users')
             ->groupBy('id', 'name');
-        $this->assertEquals('SELECT id, name FROM users GROUP BY id, name', $query->getSql());
+        $this->assertSame('SELECT id, name FROM users GROUP BY id, name', $query->getSql());
     }
 
     /**
@@ -210,7 +210,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query->from('users')
             ->groupBy('name')
             ->having('COUNT(name) > 1');
-        $this->assertEquals('SELECT name FROM users GROUP BY name HAVING (COUNT(name) > 1)', $query->getSql());
+        $this->assertSame('SELECT name FROM users GROUP BY name HAVING (COUNT(name) > 1)', $query->getSql());
     }
 
     /**
@@ -222,7 +222,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query->from('users')
             ->groupBy('name')
             ->having($this->condition);
-        $this->assertEquals('SELECT name FROM users GROUP BY name HAVING (c1 IN (?))', $query->getSql());
+        $this->assertSame('SELECT name FROM users GROUP BY name HAVING (c1 IN (?))', $query->getSql());
         $this->assertEquals([[1, PDO::PARAM_INT]], $query->getParameters());
     }
 
@@ -234,7 +234,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query = new SelectQuery('id');
         $query->from('users', 'u')
             ->innerJoin('log', 'l', 'l.userid = u.id');
-        $this->assertEquals('SELECT id FROM users AS u INNER JOIN log AS l ON l.userid = u.id', $query->getSql());
+        $this->assertSame('SELECT id FROM users AS u INNER JOIN log AS l ON l.userid = u.id', $query->getSql());
     }
 
     /**
@@ -245,7 +245,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query = new SelectQuery('u.id');
         $query->from('users', 'u')
             ->join('log', 'l', 'l.userid = u.id');
-        $this->assertEquals('SELECT u.id FROM users AS u INNER JOIN log AS l ON l.userid = u.id', $query->getSql());
+        $this->assertSame('SELECT u.id FROM users AS u INNER JOIN log AS l ON l.userid = u.id', $query->getSql());
     }
 
     /**
@@ -256,7 +256,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query = new SelectQuery('id');
         $query->from('users', 'u')
             ->leftJoin('log', 'l', 'l.userid = u.id');
-        $this->assertEquals('SELECT id FROM users AS u LEFT JOIN log AS l ON l.userid = u.id', $query->getSql());
+        $this->assertSame('SELECT id FROM users AS u LEFT JOIN log AS l ON l.userid = u.id', $query->getSql());
     }
 
     /**
@@ -267,7 +267,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query = new SelectQuery('id', 'name');
         $query->from('users')
             ->limit(5);
-        $this->assertEquals('SELECT id, name FROM users LIMIT 5', $query->getSql());
+        $this->assertSame('SELECT id, name FROM users LIMIT 5', $query->getSql());
     }
 
     /**
@@ -278,7 +278,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query = new SelectQuery('id', 'name');
         $query->from('users')
             ->limit(':limit');
-        $this->assertEquals('SELECT id, name FROM users LIMIT :limit', $query->getSql());
+        $this->assertSame('SELECT id, name FROM users LIMIT :limit', $query->getSql());
     }
 
     /**
@@ -289,7 +289,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query = new SelectQuery('id');
         $query->from('users')
             ->where('id > 10', $this->condition);
-        $this->assertEquals('SELECT id FROM users WHERE (id > 10) AND (c1 IN (?))',
+        $this->assertSame('SELECT id FROM users WHERE (id > 10) AND (c1 IN (?))',
             $query->getSql());
         $this->assertEquals([[1, PDO::PARAM_INT]], $query->getParameters());
     }
@@ -303,7 +303,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query->from('users', 'u')
             ->join('log', 'l', 'l.userid = u.id')
             ->join('emails', 'e', 'e.userid = u.id');
-        $this->assertEquals('SELECT id FROM users AS u INNER JOIN log AS l ON l.userid = u.id INNER JOIN emails AS e ON e.userid = u.id',
+        $this->assertSame('SELECT id FROM users AS u INNER JOIN log AS l ON l.userid = u.id INNER JOIN emails AS e ON e.userid = u.id',
             $query->getSql());
     }
 
@@ -315,7 +315,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query = new SelectQuery('id', 'name');
         $query->from('users')
             ->offset(5);
-        $this->assertEquals('SELECT id, name FROM users OFFSET 5', $query->getSql());
+        $this->assertSame('SELECT id, name FROM users OFFSET 5', $query->getSql());
     }
 
     /**
@@ -326,7 +326,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query = new SelectQuery('id', 'name');
         $query->from('users')
             ->offset(':offset');
-        $this->assertEquals('SELECT id, name FROM users OFFSET :offset', $query->getSql());
+        $this->assertSame('SELECT id, name FROM users OFFSET :offset', $query->getSql());
     }
 
     /**
@@ -339,7 +339,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
             ->groupBy('name')
             ->having('COUNT(name) > 1')
             ->orHaving('COUNT(name) < 5');
-        $this->assertEquals('SELECT name FROM users GROUP BY name HAVING (COUNT(name) > 1) OR (COUNT(name) < 5)',
+        $this->assertSame('SELECT name FROM users GROUP BY name HAVING (COUNT(name) > 1) OR (COUNT(name) < 5)',
             $query->getSql());
     }
 
@@ -353,7 +353,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
             ->groupBy('name')
             ->having('COUNT(name) > 1')
             ->orHaving($this->condition);
-        $this->assertEquals('SELECT name FROM users GROUP BY name HAVING (COUNT(name) > 1) OR (c1 IN (?))',
+        $this->assertSame('SELECT name FROM users GROUP BY name HAVING (COUNT(name) > 1) OR (c1 IN (?))',
             $query->getSql());
         $this->assertEquals([[1, PDO::PARAM_INT]], $query->getParameters());
     }
@@ -367,7 +367,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query->from('users')
             ->where('id > 10')
             ->orWhere("name <> 'dave'");
-        $this->assertEquals("SELECT id FROM users WHERE (id > 10) OR (name <> 'dave')", $query->getSql());
+        $this->assertSame("SELECT id FROM users WHERE (id > 10) OR (name <> 'dave')", $query->getSql());
     }
 
     /**
@@ -379,7 +379,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query->from('users')
             ->where('id > 10')
             ->orWhere($this->condition);
-        $this->assertEquals('SELECT id FROM users WHERE (id > 10) OR (c1 IN (?))', $query->getSql());
+        $this->assertSame('SELECT id FROM users WHERE (id > 10) OR (c1 IN (?))', $query->getSql());
         $this->assertEquals([[1, PDO::PARAM_INT]], $query->getParameters());
     }
 
@@ -391,7 +391,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query = new SelectQuery('id', 'name');
         $query->from('users')
             ->orderBy('id ASC', 'name DESC');
-        $this->assertEquals('SELECT id, name FROM users ORDER BY id ASC, name DESC', $query->getSql());
+        $this->assertSame('SELECT id, name FROM users ORDER BY id ASC, name DESC', $query->getSql());
     }
 
     /**
@@ -400,7 +400,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
     public function testReallyBasicQuery()
     {
         $query = new SelectQuery('id');
-        $this->assertEquals('SELECT id', $query->getSql());
+        $this->assertSame('SELECT id', $query->getSql());
     }
 
     /**
@@ -411,7 +411,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query = new SelectQuery('id');
         $query->from('users', 'u')
             ->rightJoin('log', 'l', 'l.userid = u.id');
-        $this->assertEquals('SELECT id FROM users AS u RIGHT JOIN log AS l ON l.userid = u.id', $query->getSql());
+        $this->assertSame('SELECT id FROM users AS u RIGHT JOIN log AS l ON l.userid = u.id', $query->getSql());
     }
 
     /**
@@ -424,7 +424,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
             ->groupBy('name')
             ->having('COUNT(name) > 1')
             ->having('COUNT(name) < 5');
-        $this->assertEquals('SELECT name FROM users GROUP BY name HAVING (COUNT(name) < 5)', $query->getSql());
+        $this->assertSame('SELECT name FROM users GROUP BY name HAVING (COUNT(name) < 5)', $query->getSql());
     }
 
     /**
@@ -436,7 +436,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query->from('users')
             ->where('id = 1')
             ->where('id = 2');
-        $this->assertEquals('SELECT name FROM users WHERE (id = 2)', $query->getSql());
+        $this->assertSame('SELECT name FROM users WHERE (id = 2)', $query->getSql());
     }
 
     /**
@@ -447,7 +447,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query = new SelectQuery('id');
         $query->from('users')
             ->where('id > 10', "name <> 'dave'");
-        $this->assertEquals("SELECT id FROM users WHERE (id > 10) AND (name <> 'dave')", $query->getSql());
+        $this->assertSame("SELECT id FROM users WHERE (id > 10) AND (name <> 'dave')", $query->getSql());
     }
 
     /**
@@ -458,7 +458,7 @@ class SelectQueryTest extends \PHPUnit\Framework\TestCase
         $query = new SelectQuery('id');
         $query->from('users')
             ->where($this->condition, $this->condition);
-        $this->assertEquals('SELECT id FROM users WHERE (c1 IN (?)) AND (c1 IN (?))', $query->getSql());
+        $this->assertSame('SELECT id FROM users WHERE (c1 IN (?)) AND (c1 IN (?))', $query->getSql());
         $this->assertEquals([[1, PDO::PARAM_INT], [1, PDO::PARAM_INT]], $query->getParameters());
     }
 }

--- a/src/Opulence/QueryBuilders/Tests/UpdateQueryTest.php
+++ b/src/Opulence/QueryBuilders/Tests/UpdateQueryTest.php
@@ -44,7 +44,7 @@ class UpdateQueryTest extends \PHPUnit\Framework\TestCase
     {
         $query = new UpdateQuery('users', '', ['name' => 'david']);
         $query->addColumnValues(['email' => 'bar@foo.com']);
-        $this->assertEquals('UPDATE users SET name = ?, email = ?', $query->getSql());
+        $this->assertSame('UPDATE users SET name = ?, email = ?', $query->getSql());
         $this->assertEquals([
             ['david', PDO::PARAM_STR],
             ['bar@foo.com', PDO::PARAM_STR]
@@ -57,7 +57,7 @@ class UpdateQueryTest extends \PHPUnit\Framework\TestCase
     public function testBasicQuery()
     {
         $query = new UpdateQuery('users', '', ['name' => 'david']);
-        $this->assertEquals('UPDATE users SET name = ?', $query->getSql());
+        $this->assertSame('UPDATE users SET name = ?', $query->getSql());
         $this->assertEquals([
             ['david', PDO::PARAM_STR]
         ], $query->getParameters());
@@ -69,7 +69,7 @@ class UpdateQueryTest extends \PHPUnit\Framework\TestCase
     public function testSimpleExpression()
     {
         $query = new UpdateQuery('users', '', ['valid_until' => new Expression('NOW()')]);
-        $this->assertEquals('UPDATE users SET valid_until = NOW()', $query->getSql());
+        $this->assertSame('UPDATE users SET valid_until = NOW()', $query->getSql());
         $this->assertEquals([], $query->getParameters());
     }
 
@@ -80,7 +80,7 @@ class UpdateQueryTest extends \PHPUnit\Framework\TestCase
     {
         $query = new UpdateQuery('users', '',
             ['is_val_even' => new Expression('(val + ?) % ?', ['1', PDO::PARAM_INT], [2, PDO::PARAM_INT])]);
-        $this->assertEquals('UPDATE users SET is_val_even = (val + ?) % ?', $query->getSql());
+        $this->assertSame('UPDATE users SET is_val_even = (val + ?) % ?', $query->getSql());
         $this->assertEquals([
             ['1', PDO::PARAM_INT],
             [2, PDO::PARAM_INT],
@@ -99,7 +99,7 @@ class UpdateQueryTest extends \PHPUnit\Framework\TestCase
             ->orWhere('u.name = ?')
             ->andWhere('subscriptions.userid = u.id', "subscriptions.type = 'customer'")
             ->addUnnamedPlaceholderValues([[2, PDO::PARAM_INT], [18175, PDO::PARAM_INT], 'foo@bar.com', 'dave']);
-        $this->assertEquals("UPDATE users AS u SET name = ?, email = ?, is_val_even = (val + ?) % ? WHERE (u.id = ?) AND (emails.userid = u.id) AND (emails.email = ?) OR (u.name = ?) AND (subscriptions.userid = u.id) AND (subscriptions.type = 'customer')",
+        $this->assertSame("UPDATE users AS u SET name = ?, email = ?, is_val_even = (val + ?) % ? WHERE (u.id = ?) AND (emails.userid = u.id) AND (emails.email = ?) OR (u.name = ?) AND (subscriptions.userid = u.id) AND (subscriptions.type = 'customer')",
             $query->getSql());
         $this->assertSame([
             ['david', PDO::PARAM_STR],
@@ -120,7 +120,7 @@ class UpdateQueryTest extends \PHPUnit\Framework\TestCase
         $query = new UpdateQuery('users', '', ['name' => 'david']);
         $query->where('id = ?')
             ->addUnnamedPlaceholderValue(18175, PDO::PARAM_INT);
-        $this->assertEquals('UPDATE users SET name = ? WHERE (id = ?)', $query->getSql());
+        $this->assertSame('UPDATE users SET name = ? WHERE (id = ?)', $query->getSql());
         $this->assertEquals([
             ['david', PDO::PARAM_STR],
             [18175, PDO::PARAM_INT]
@@ -135,7 +135,7 @@ class UpdateQueryTest extends \PHPUnit\Framework\TestCase
         $query = new UpdateQuery('users', '', ['name' => 'david']);
         $query->where($this->condition)
             ->addUnnamedPlaceholderValue(18175, PDO::PARAM_INT);
-        $this->assertEquals('UPDATE users SET name = ? WHERE (c1 IN (?))', $query->getSql());
+        $this->assertSame('UPDATE users SET name = ? WHERE (c1 IN (?))', $query->getSql());
         $this->assertEquals([
             ['david', PDO::PARAM_STR],
             [1, PDO::PARAM_INT],

--- a/src/Opulence/Redis/Tests/RedisTest.php
+++ b/src/Opulence/Redis/Tests/RedisTest.php
@@ -45,7 +45,7 @@ class RedisTest extends \PHPUnit\Framework\TestCase
                 'foo' => $foo
             ]
         );
-        $this->assertEquals('foo', $redis->get('baz'));
+        $this->assertSame('foo', $redis->get('baz'));
     }
 
     /**

--- a/src/Opulence/Redis/Tests/Types/TypeMapperTest.php
+++ b/src/Opulence/Redis/Tests/Types/TypeMapperTest.php
@@ -44,7 +44,7 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     public function testConvertingFromRedisTimestamp()
     {
         $time = new DateTime('now');
-        $this->assertEquals($time->getTimestamp(),
+        $this->assertSame($time->getTimestamp(),
             $this->typeMapper->fromRedisTimestamp($time->getTimestamp())->getTimestamp());
     }
 
@@ -70,7 +70,7 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     public function testConvertingToRedisTimestamp()
     {
         $time = new DateTime('now');
-        $this->assertEquals($time->getTimestamp(), $this->typeMapper->toRedisTimestamp($time));
+        $this->assertSame($time->getTimestamp(), $this->typeMapper->toRedisTimestamp($time));
     }
 
     /**
@@ -79,7 +79,7 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
     public function testConvertingToRedisTimestampFromImmutable()
     {
         $time = new DateTimeImmutable('now');
-        $this->assertEquals($time->getTimestamp(), $this->typeMapper->toRedisTimestamp($time));
+        $this->assertSame($time->getTimestamp(), $this->typeMapper->toRedisTimestamp($time));
     }
 
     /**
@@ -100,7 +100,7 @@ class TypeMapperTest extends \PHPUnit\Framework\TestCase
         date_default_timezone_set($newTimezone);
         $time = new DateTime('now');
         $redisTime = $this->typeMapper->fromRedisTimestamp($time->getTimestamp());
-        $this->assertEquals($newTimezone, $redisTime->getTimezone()->getName());
+        $this->assertSame($newTimezone, $redisTime->getTimezone()->getName());
         // Reset the timezone
         date_default_timezone_set($currTimezone);
     }

--- a/src/Opulence/Routing/Tests/Dispatchers/MiddlewarePipelineTest.php
+++ b/src/Opulence/Routing/Tests/Dispatchers/MiddlewarePipelineTest.php
@@ -44,7 +44,7 @@ class MiddlewarePipelineTest extends \PHPUnit\Framework\TestCase
         /** @var Response $response */
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEmpty($response->getContent());
-        $this->assertEquals(ResponseHeaders::HTTP_OK, $response->getStatusCode());
+        $this->assertSame(ResponseHeaders::HTTP_OK, $response->getStatusCode());
     }
 
     /**
@@ -61,7 +61,7 @@ class MiddlewarePipelineTest extends \PHPUnit\Framework\TestCase
         };
         $response = $this->middlewarePipeline->send(Request::createFromGlobals(), $middleware, $controller);
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals('foo:something:something', $response->getContent());
-        $this->assertEquals(ResponseHeaders::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('foo:something:something', $response->getContent());
+        $this->assertSame(ResponseHeaders::HTTP_OK, $response->getStatusCode());
     }
 }

--- a/src/Opulence/Routing/Tests/Dispatchers/RouteDispatcherTest.php
+++ b/src/Opulence/Routing/Tests/Dispatchers/RouteDispatcherTest.php
@@ -95,7 +95,7 @@ class RouteDispatcherTest extends \PHPUnit\Framework\TestCase
         $response = $this->dispatcher->dispatch($route, $this->request, $controller);
         $this->assertInstanceOf('Closure', $controller);
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals('Closure', $response->getContent());
+        $this->assertSame('Closure', $response->getContent());
     }
 
     /**
@@ -117,7 +117,7 @@ class RouteDispatcherTest extends \PHPUnit\Framework\TestCase
         $response = $this->dispatcher->dispatch($route, $this->request, $controller);
         $this->assertInstanceOf('Closure', $controller);
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals(Request::class . ':123', $response->getContent());
+        $this->assertSame(Request::class . ':123', $response->getContent());
     }
 
     /**
@@ -132,7 +132,7 @@ class RouteDispatcherTest extends \PHPUnit\Framework\TestCase
         $response = $this->dispatcher->dispatch($route, $this->request, $controller);
         $this->assertInstanceOf(MockController::class, $controller);
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals('invoke', $response->getContent());
+        $this->assertSame('invoke', $response->getContent());
     }
 
     /**
@@ -184,7 +184,7 @@ class RouteDispatcherTest extends \PHPUnit\Framework\TestCase
         $response = $this->dispatcher->dispatch($route, $this->request, $controller);
         $this->assertInstanceOf(NonOpulenceController::class, $controller);
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals('Id: 123', $response->getContent());
+        $this->assertSame('Id: 123', $response->getContent());
     }
 
     /**
@@ -207,7 +207,7 @@ class RouteDispatcherTest extends \PHPUnit\Framework\TestCase
         $route = $this->getCompiledRoute(
             new Route(['GET'], '/foo', MockController::class . '@protectedMethod')
         );
-        $this->assertEquals('protectedMethod', $this->dispatcher->dispatch($route, $this->request)->getContent());
+        $this->assertSame('protectedMethod', $this->dispatcher->dispatch($route, $this->request)->getContent());
     }
 
     /**
@@ -223,7 +223,7 @@ class RouteDispatcherTest extends \PHPUnit\Framework\TestCase
             ]
         ];
         $route = $this->getCompiledRoute(new Route(['GET'], '/foo', $controller, $options));
-        $this->assertEquals(
+        $this->assertSame(
             'noParameters:something',
             $this->dispatcher->dispatch($route, $this->request)->getContent()
         );
@@ -241,8 +241,8 @@ class RouteDispatcherTest extends \PHPUnit\Framework\TestCase
         );
         $response = $this->dispatcher->dispatch($route, $this->request, $controller);
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals('Closure', $response->getContent());
-        $this->assertEquals(ResponseHeaders::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('Closure', $response->getContent());
+        $this->assertSame(ResponseHeaders::HTTP_OK, $response->getStatusCode());
     }
 
     /**
@@ -269,7 +269,7 @@ class RouteDispatcherTest extends \PHPUnit\Framework\TestCase
             'middleware' => ReturnsSomethingMiddleware::class
         ];
         $route = $this->getCompiledRoute(new Route(['GET'], '/foo', $controller, $options));
-        $this->assertEquals(
+        $this->assertSame(
             'noParameters:something',
             $this->dispatcher->dispatch($route, $this->request)->getContent()
         );
@@ -304,7 +304,7 @@ class RouteDispatcherTest extends \PHPUnit\Framework\TestCase
         $response = $this->dispatcher->dispatch($route, $this->request, $controller);
         $this->assertInstanceOf('Closure', $controller);
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals('Closure: Id: 123', $response->getContent());
+        $this->assertSame('Closure: Id: 123', $response->getContent());
     }
 
     /**
@@ -316,8 +316,8 @@ class RouteDispatcherTest extends \PHPUnit\Framework\TestCase
             new Route(['GET'], '/foo', MockController::class . '@returnsText')
         );
         $response = $this->dispatcher->dispatch($route, $this->request);
-        $this->assertEquals('returnsText', $response->getContent());
-        $this->assertEquals(ResponseHeaders::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('returnsText', $response->getContent());
+        $this->assertSame(ResponseHeaders::HTTP_OK, $response->getStatusCode());
     }
 
     /**
@@ -346,7 +346,7 @@ class RouteDispatcherTest extends \PHPUnit\Framework\TestCase
         $response = $this->dispatcher->dispatch($route, $this->request, $controller);
         $this->assertInstanceOf('Closure', $controller);
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals('Closure: Id: 123', $response->getContent());
+        $this->assertSame('Closure: Id: 123', $response->getContent());
     }
 
     /**
@@ -373,7 +373,7 @@ class RouteDispatcherTest extends \PHPUnit\Framework\TestCase
         ];
         $route = $this->getCompiledRoute(new Route(['GET'], '/foo', $controller, $options));
         $response = $this->dispatcher->dispatch($route, $this->request);
-        $this->assertEquals('bar', $response->getHeaders()->get('parameters'));
+        $this->assertSame('bar', $response->getHeaders()->get('parameters'));
     }
 
     /**

--- a/src/Opulence/Routing/Tests/Middleware/MiddlewareParametersTest.php
+++ b/src/Opulence/Routing/Tests/Middleware/MiddlewareParametersTest.php
@@ -33,7 +33,7 @@ class MiddlewareParametersTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingMiddlewareClassName()
     {
-        $this->assertEquals('foo', $this->parameters->getMiddlewareClassName());
+        $this->assertSame('foo', $this->parameters->getMiddlewareClassName());
     }
 
     /**

--- a/src/Opulence/Routing/Tests/Middleware/ParameterizedMiddlewareTest.php
+++ b/src/Opulence/Routing/Tests/Middleware/ParameterizedMiddlewareTest.php
@@ -37,7 +37,7 @@ class ParameterizedMiddlewareTest extends \PHPUnit\Framework\TestCase
         /** @var MiddlewareParameters $parameters */
         $parameters = ParameterizedMiddlewareMock::withParameters(['bar' => 'baz']);
         $this->assertInstanceOf(MiddlewareParameters::class, $parameters);
-        $this->assertEquals(ParameterizedMiddlewareMock::class, $parameters->getMiddlewareClassName());
+        $this->assertSame(ParameterizedMiddlewareMock::class, $parameters->getMiddlewareClassName());
         $this->assertEquals(['bar' => 'baz'], $parameters->getParameters());
     }
 }

--- a/src/Opulence/Routing/Tests/RouterTest.php
+++ b/src/Opulence/Routing/Tests/RouterTest.php
@@ -146,8 +146,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
         $getRoutes = $this->router->getRouteCollection()->get(RequestMethods::GET);
         /** @var Route[] $postRoutes */
         $postRoutes = $this->router->getRouteCollection()->get(RequestMethods::POST);
-        $this->assertEquals("\d+", $getRoutes[0]->getVarRegex('id'));
-        $this->assertEquals("\d+", $postRoutes[0]->getVarRegex('id'));
+        $this->assertSame("\d+", $getRoutes[0]->getVarRegex('id'));
+        $this->assertSame("\d+", $postRoutes[0]->getVarRegex('id'));
     }
 
     /**
@@ -184,9 +184,9 @@ class RouterTest extends \PHPUnit\Framework\TestCase
         $getRoutes = $this->router->getRouteCollection()->get(RequestMethods::GET);
         /** @var Route[] $deleteRoutes */
         $deleteRoutes = $this->router->getRouteCollection()->get(RequestMethods::DELETE);
-        $this->assertEquals('/foo/bar', $getRoutes[0]->getRawPath());
+        $this->assertSame('/foo/bar', $getRoutes[0]->getRawPath());
         $this->assertEquals(['foo1', 'foo2'], $getRoutes[0]->getMiddleware());
-        $this->assertEquals('/foo/blah', $deleteRoutes[0]->getRawPath());
+        $this->assertSame('/foo/blah', $deleteRoutes[0]->getRawPath());
         $this->assertEquals(['foo1', 'foo2'], $deleteRoutes[0]->getMiddleware());
     }
 
@@ -212,11 +212,11 @@ class RouterTest extends \PHPUnit\Framework\TestCase
         $getRoutes = $this->router->getRouteCollection()->get(RequestMethods::GET);
         /** @var Route[] $deleteRoutes */
         $deleteRoutes = $this->router->getRouteCollection()->get(RequestMethods::DELETE);
-        $this->assertEquals('/foo/bar', $getRoutes[0]->getRawPath());
+        $this->assertSame('/foo/bar', $getRoutes[0]->getRawPath());
         $this->assertEquals(['foo1', 'foo2', 'foo3', 'foo4'], $getRoutes[0]->getMiddleware());
-        $this->assertEquals('/asdf', $getRoutes[1]->getRawPath());
+        $this->assertSame('/asdf', $getRoutes[1]->getRawPath());
         $this->assertEquals(['foo3', 'foo4'], $getRoutes[1]->getMiddleware());
-        $this->assertEquals('/foo/blah', $deleteRoutes[0]->getRawPath());
+        $this->assertSame('/foo/blah', $deleteRoutes[0]->getRawPath());
         $this->assertEquals(['foo1', 'foo2', 'foo3', 'foo4'], $deleteRoutes[0]->getMiddleware());
     }
 
@@ -301,14 +301,14 @@ class RouterTest extends \PHPUnit\Framework\TestCase
         $getRoutes = $this->router->getRouteCollection()->get(RequestMethods::GET);
         /** @var Route[] $deleteRoutes */
         $deleteRoutes = $this->router->getRouteCollection()->get(RequestMethods::DELETE);
-        $this->assertEquals('/foo/bar', $getRoutes[0]->getRawPath());
-        $this->assertEquals(MockController::class, $getRoutes[0]->getControllerName());
+        $this->assertSame('/foo/bar', $getRoutes[0]->getRawPath());
+        $this->assertSame(MockController::class, $getRoutes[0]->getControllerName());
         $this->assertEquals(['foo1', 'foo2'], $getRoutes[0]->getMiddleware());
-        $this->assertEquals('/foo/asdf/jkl', $getRoutes[1]->getRawPath());
-        $this->assertEquals(MockController::class, $getRoutes[1]->getControllerName());
+        $this->assertSame('/foo/asdf/jkl', $getRoutes[1]->getRawPath());
+        $this->assertSame(MockController::class, $getRoutes[1]->getControllerName());
         $this->assertEquals(['foo1', 'foo2', 'foo3', 'foo4'], $getRoutes[1]->getMiddleware());
-        $this->assertEquals('/foo/blah', $deleteRoutes[0]->getRawPath());
-        $this->assertEquals(MockController::class, $deleteRoutes[0]->getControllerName());
+        $this->assertSame('/foo/blah', $deleteRoutes[0]->getRawPath());
+        $this->assertSame(MockController::class, $deleteRoutes[0]->getControllerName());
         $this->assertEquals(['foo1', 'foo2'], $deleteRoutes[0]->getMiddleware());
     }
 
@@ -328,9 +328,9 @@ class RouterTest extends \PHPUnit\Framework\TestCase
         });
         /** @var Route[] $getRoutes */
         $getRoutes = $this->router->getRouteCollection()->get(RequestMethods::GET);
-        $this->assertEquals("\d*", $getRoutes[0]->getVarRegex('id'));
-        $this->assertEquals("\w+", $getRoutes[1]->getVarRegex('id'));
-        $this->assertEquals("\d+", $getRoutes[2]->getVarRegex('id'));
+        $this->assertSame("\d*", $getRoutes[0]->getVarRegex('id'));
+        $this->assertSame("\w+", $getRoutes[1]->getVarRegex('id'));
+        $this->assertSame("\d+", $getRoutes[2]->getVarRegex('id'));
     }
 
     /**
@@ -449,7 +449,7 @@ class RouterTest extends \PHPUnit\Framework\TestCase
         $response = $this->router->route($request);
         $this->assertInstanceOf(Response::class, $response);
         $this->assertInstanceOf(NonOpulenceController::class, $this->router->getMatchedController());
-        $this->assertEquals('Id: 123', $response->getContent());
+        $this->assertSame('Id: 123', $response->getContent());
     }
 
     /**
@@ -493,8 +493,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
         $getRoutes = $this->router->getRouteCollection()->get(RequestMethods::GET);
         /** @var Route[] $postRoutes */
         $postRoutes = $this->router->getRouteCollection()->get(RequestMethods::POST);
-        $this->assertEquals('google.com', $getRoutes[0]->getRawHost());
-        $this->assertEquals('google.com', $postRoutes[0]->getRawHost());
+        $this->assertSame('google.com', $getRoutes[0]->getRawHost());
+        $this->assertSame('google.com', $postRoutes[0]->getRawHost());
     }
 
     /**
@@ -510,8 +510,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
         $getRoutes = $this->router->getRouteCollection()->get(RequestMethods::GET);
         /** @var Route[] $postRoutes */
         $postRoutes = $this->router->getRouteCollection()->get(RequestMethods::POST);
-        $this->assertEquals('MyApp\\Controllers\\ControllerA', $getRoutes[0]->getControllerName());
-        $this->assertEquals('MyApp\\Controllers\\ControllerB', $postRoutes[0]->getControllerName());
+        $this->assertSame('MyApp\\Controllers\\ControllerA', $getRoutes[0]->getControllerName());
+        $this->assertSame('MyApp\\Controllers\\ControllerB', $postRoutes[0]->getControllerName());
     }
 
     /**
@@ -527,8 +527,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
         $getRoutes = $this->router->getRouteCollection()->get(RequestMethods::GET);
         /** @var Route[] $postRoutes */
         $postRoutes = $this->router->getRouteCollection()->get(RequestMethods::POST);
-        $this->assertEquals('MyApp\\Controllers\\ControllerA', $getRoutes[0]->getControllerName());
-        $this->assertEquals('MyApp\\Controllers\\ControllerB', $postRoutes[0]->getControllerName());
+        $this->assertSame('MyApp\\Controllers\\ControllerA', $getRoutes[0]->getControllerName());
+        $this->assertSame('MyApp\\Controllers\\ControllerB', $postRoutes[0]->getControllerName());
     }
 
     /**
@@ -546,8 +546,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
         $getRoutes = $this->router->getRouteCollection()->get(RequestMethods::GET);
         /** @var Route[] $postRoutes */
         $postRoutes = $this->router->getRouteCollection()->get(RequestMethods::POST);
-        $this->assertEquals('mail.google.com', $getRoutes[0]->getRawHost());
-        $this->assertEquals('mail.google.com', $postRoutes[0]->getRawHost());
+        $this->assertSame('mail.google.com', $getRoutes[0]->getRawHost());
+        $this->assertSame('mail.google.com', $postRoutes[0]->getRawHost());
     }
 
     /**

--- a/src/Opulence/Routing/Tests/Routes/Caching/FileCacheTest.php
+++ b/src/Opulence/Routing/Tests/Routes/Caching/FileCacheTest.php
@@ -69,7 +69,7 @@ class FileCacheTest extends \PHPUnit\Framework\TestCase
         $this->assertFileNotExists($this->cachedRouteFilePath);
         $routes = $this->cache->get($this->cachedRouteFilePath, $router, $this->rawRouteFilePath);
         $this->assertFileExists($this->cachedRouteFilePath);
-        $this->assertEquals(base64_encode(serialize($routes)), file_get_contents($this->cachedRouteFilePath));
+        $this->assertSame(base64_encode(serialize($routes)), file_get_contents($this->cachedRouteFilePath));
     }
 
     /**
@@ -83,7 +83,7 @@ class FileCacheTest extends \PHPUnit\Framework\TestCase
         file_put_contents($this->cachedRouteFilePath, base64_encode(serialize($routes)));
         $routes = $this->cache->get($this->cachedRouteFilePath, $router, $this->rawRouteFilePath);
         $this->assertFileExists($this->cachedRouteFilePath);
-        $this->assertEquals(base64_encode(serialize($routes)), file_get_contents($this->cachedRouteFilePath));
+        $this->assertSame(base64_encode(serialize($routes)), file_get_contents($this->cachedRouteFilePath));
     }
 
     /**
@@ -95,7 +95,7 @@ class FileCacheTest extends \PHPUnit\Framework\TestCase
         require $this->rawRouteFilePath;
         $setRoutes = $router->getRouteCollection();
         $this->cache->set($this->cachedRouteFilePath, $setRoutes);
-        $this->assertEquals(base64_encode(serialize($setRoutes)), file_get_contents($this->cachedRouteFilePath));
+        $this->assertSame(base64_encode(serialize($setRoutes)), file_get_contents($this->cachedRouteFilePath));
         $this->assertFileExists($this->cachedRouteFilePath);
         $getRoutes = $this->cache->get($this->cachedRouteFilePath, $router, $this->rawRouteFilePath);
         $this->assertEquals($getRoutes, $setRoutes);

--- a/src/Opulence/Routing/Tests/Routes/CompiledRouteTest.php
+++ b/src/Opulence/Routing/Tests/Routes/CompiledRouteTest.php
@@ -57,8 +57,8 @@ class CompiledRouteTest extends \PHPUnit\Framework\TestCase
         $parsedRoute->setHostRegex("foo\.bar\.com");
         $parsedRoute->setPathRegex('baz.*');
         $compiledRoute = new CompiledRoute($parsedRoute, true, []);
-        $this->assertEquals($parsedRoute->getHostRegex(), $compiledRoute->getHostRegex());
-        $this->assertEquals($parsedRoute->getPathRegex(), $compiledRoute->getPathRegex());
+        $this->assertSame($parsedRoute->getHostRegex(), $compiledRoute->getHostRegex());
+        $this->assertSame($parsedRoute->getPathRegex(), $compiledRoute->getPathRegex());
         $this->assertEquals($parsedRoute->getDefaultValue('bar'), $compiledRoute->getDefaultValue('bar'));
     }
 
@@ -75,7 +75,7 @@ class CompiledRouteTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingPathVariable()
     {
-        $this->assertEquals('bar', $this->compiledRoute->getPathVar('foo'));
+        $this->assertSame('bar', $this->compiledRoute->getPathVar('foo'));
     }
 
     /**

--- a/src/Opulence/Routing/Tests/Routes/Compilers/Parsers/ParserTest.php
+++ b/src/Opulence/Routing/Tests/Routes/Compilers/Parsers/ParserTest.php
@@ -38,7 +38,7 @@ class ParserTest extends \PHPUnit\Framework\TestCase
     {
         $route = new Route(['get'], '/foo', 'foo@bar');
         $parsedRoute = $this->parser->parse($route);
-        $this->assertEquals('#^.*$#', $parsedRoute->getHostRegex());
+        $this->assertSame('#^.*$#', $parsedRoute->getHostRegex());
     }
 
     /**
@@ -105,7 +105,7 @@ class ParserTest extends \PHPUnit\Framework\TestCase
                 )
             )
         );
-        $this->assertEquals('123', $parsedRoute->getDefaultValue('blah'));
+        $this->assertSame('123', $parsedRoute->getDefaultValue('blah'));
     }
 
     /**
@@ -218,7 +218,7 @@ class ParserTest extends \PHPUnit\Framework\TestCase
                 )
             )
         );
-        $this->assertEquals('23', $parsedRoute->getDefaultValue('foo'));
+        $this->assertSame('23', $parsedRoute->getDefaultValue('foo'));
     }
 
     /**
@@ -313,7 +313,7 @@ class ParserTest extends \PHPUnit\Framework\TestCase
     {
         $route = new Route(['get'], '', 'foo@bar');
         $parsedRoute = $this->parser->parse($route);
-        $this->assertEquals('#^.*$#', $parsedRoute->getPathRegex());
+        $this->assertSame('#^.*$#', $parsedRoute->getPathRegex());
     }
 
     /**

--- a/src/Opulence/Routing/Tests/Routes/ParsedRouteTest.php
+++ b/src/Opulence/Routing/Tests/Routes/ParsedRouteTest.php
@@ -31,15 +31,15 @@ class ParsedRouteTest extends \PHPUnit\Framework\TestCase
         ]);
         $parsedRoute = new ParsedRoute($route);
         $this->assertEquals($route->getMethods(), $parsedRoute->getMethods());
-        $this->assertEquals($route->getControllerName(), $parsedRoute->getControllerName());
-        $this->assertEquals($route->getControllerMethod(), $parsedRoute->getControllerMethod());
+        $this->assertSame($route->getControllerName(), $parsedRoute->getControllerName());
+        $this->assertSame($route->getControllerMethod(), $parsedRoute->getControllerMethod());
         $this->assertEquals($route->getController(), $parsedRoute->getController());
         $this->assertEquals($route->usesCallable(), $parsedRoute->usesCallable());
-        $this->assertEquals($route->getName(), $parsedRoute->getName());
+        $this->assertSame($route->getName(), $parsedRoute->getName());
         $this->assertEquals($route->isSecure(), $parsedRoute->isSecure());
         $this->assertEquals($route->getMiddleware(), $parsedRoute->getMiddleware());
-        $this->assertEquals($route->getRawHost(), $parsedRoute->getRawHost());
-        $this->assertEquals($route->getRawPath(), $parsedRoute->getRawPath());
+        $this->assertSame($route->getRawHost(), $parsedRoute->getRawHost());
+        $this->assertSame($route->getRawPath(), $parsedRoute->getRawPath());
         $this->assertEquals($route->getVarRegex('bar'), $parsedRoute->getVarRegex('bar'));
     }
 
@@ -60,7 +60,7 @@ class ParsedRouteTest extends \PHPUnit\Framework\TestCase
     {
         $route = new Route('get', '/foo', 'foo@bar');
         $parsedRoute = new ParsedRoute($route);
-        $this->assertEquals('#^.*$#', $parsedRoute->getHostRegex());
+        $this->assertSame('#^.*$#', $parsedRoute->getHostRegex());
     }
 
     /**
@@ -71,7 +71,7 @@ class ParsedRouteTest extends \PHPUnit\Framework\TestCase
         $route = new Route('get', '/{foo}', 'foo@bar');
         $parsedRoute = new ParsedRoute($route);
         $parsedRoute->setDefaultValue('foo', 2);
-        $this->assertEquals(2, $parsedRoute->getDefaultValue('foo'));
+        $this->assertSame(2, $parsedRoute->getDefaultValue('foo'));
     }
 
     /**
@@ -82,7 +82,7 @@ class ParsedRouteTest extends \PHPUnit\Framework\TestCase
         $route = new Route('get', '/foo', 'foo@bar');
         $parsedRoute = new ParsedRoute($route);
         $parsedRoute->setHostRegex("#google\.com#");
-        $this->assertEquals("#google\.com#", $parsedRoute->getHostRegex());
+        $this->assertSame("#google\.com#", $parsedRoute->getHostRegex());
     }
 
     /**
@@ -93,6 +93,6 @@ class ParsedRouteTest extends \PHPUnit\Framework\TestCase
         $route = new Route('get', '/foo/{id}', 'foo@bar');
         $parsedRoute = new ParsedRoute($route);
         $parsedRoute->setPathRegex('blah');
-        $this->assertEquals('blah', $parsedRoute->getPathRegex());
+        $this->assertSame('blah', $parsedRoute->getPathRegex());
     }
 }

--- a/src/Opulence/Routing/Tests/Routes/RouteCollectionTest.php
+++ b/src/Opulence/Routing/Tests/Routes/RouteCollectionTest.php
@@ -173,7 +173,7 @@ class RouteCollectionTest extends \PHPUnit\Framework\TestCase
         $unserializedCollection = unserialize($serializedCollection);
         /** @var ParsedRoute $unserializedRoute */
         $unserializedRoute = $unserializedCollection->get('get')[0];
-        $this->assertEquals('foo@bar', $unserializedRoute->getController());
+        $this->assertSame('foo@bar', $unserializedRoute->getController());
     }
 
     /**
@@ -191,6 +191,6 @@ class RouteCollectionTest extends \PHPUnit\Framework\TestCase
         /** @var ParsedRoute $unserializedRoute */
         $unserializedRoute = $unserializedCollection->get('get')[0];
         $this->assertInstanceOf(Closure::class, $unserializedRoute->getController());
-        $this->assertEquals('foo', call_user_func($unserializedRoute->getController()));
+        $this->assertSame('foo', call_user_func($unserializedRoute->getController()));
     }
 }

--- a/src/Opulence/Routing/Tests/Routes/RouteTest.php
+++ b/src/Opulence/Routing/Tests/Routes/RouteTest.php
@@ -70,7 +70,7 @@ class RouteTest extends \PHPUnit\Framework\TestCase
     {
         $route = new Route('get', '/{foo}', 'foo@bar');
         $this->assertFalse($route->usesCallable());
-        $this->assertEquals('foo@bar', $route->getController());
+        $this->assertSame('foo@bar', $route->getController());
     }
 
     /**
@@ -79,7 +79,7 @@ class RouteTest extends \PHPUnit\Framework\TestCase
     public function testGettingControllerMethod()
     {
         $route = new Route('get', '/{foo}', 'foo@bar');
-        $this->assertEquals('bar', $route->getControllerMethod());
+        $this->assertSame('bar', $route->getControllerMethod());
     }
 
     /**
@@ -88,8 +88,8 @@ class RouteTest extends \PHPUnit\Framework\TestCase
     public function testGettingControllerName()
     {
         $route = new Route('get', '/{foo}', 'foo@bar');
-        $this->assertEquals('foo', $route->getControllerName());
-        $this->assertEquals('foo@bar', $route->getController());
+        $this->assertSame('foo', $route->getControllerName());
+        $this->assertSame('foo@bar', $route->getController());
     }
 
     /**
@@ -143,7 +143,7 @@ class RouteTest extends \PHPUnit\Framework\TestCase
     public function testGettingRawPath()
     {
         $route = new Route('get', '/foo/{id}', 'foo@bar');
-        $this->assertEquals('/foo/{id}', $route->getRawPath());
+        $this->assertSame('/foo/{id}', $route->getRawPath());
     }
 
     /**
@@ -164,7 +164,7 @@ class RouteTest extends \PHPUnit\Framework\TestCase
             'vars' => ['bar' => "\d+"]
         ];
         $route = new Route('get', '/foo', 'foo@bar', $options);
-        $this->assertEquals("\d+", $route->getVarRegex('bar'));
+        $this->assertSame("\d+", $route->getVarRegex('bar'));
     }
 
     /**
@@ -260,8 +260,8 @@ class RouteTest extends \PHPUnit\Framework\TestCase
     {
         $route = new Route('get', '/{foo}', 'foo@bar');
         $route->setControllerMethod('blah');
-        $this->assertEquals('blah', $route->getControllerMethod());
-        $this->assertEquals('foo@blah', $route->getController());
+        $this->assertSame('blah', $route->getControllerMethod());
+        $this->assertSame('foo@blah', $route->getController());
     }
 
     /**
@@ -271,8 +271,8 @@ class RouteTest extends \PHPUnit\Framework\TestCase
     {
         $route = new Route('get', '/{foo}', 'foo@bar');
         $route->setControllerName('blah');
-        $this->assertEquals('blah', $route->getControllerName());
-        $this->assertEquals('blah@bar', $route->getController());
+        $this->assertSame('blah', $route->getControllerName());
+        $this->assertSame('blah@bar', $route->getController());
     }
 
     /**
@@ -310,7 +310,7 @@ class RouteTest extends \PHPUnit\Framework\TestCase
     {
         $route = new Route('get', '/{foo}', 'foo@bar');
         $route->setName('blah');
-        $this->assertEquals('blah', $route->getName());
+        $this->assertSame('blah', $route->getName());
     }
 
     /**
@@ -322,7 +322,7 @@ class RouteTest extends \PHPUnit\Framework\TestCase
             'name' => 'blah'
         ];
         $route = new Route('get', '/{foo}', 'foo@bar', $options);
-        $this->assertEquals('blah', $route->getName());
+        $this->assertSame('blah', $route->getName());
     }
 
     /**
@@ -332,7 +332,7 @@ class RouteTest extends \PHPUnit\Framework\TestCase
     {
         $route = new Route('get', '/foo', 'foo@bar');
         $route->setRawHost('google.com');
-        $this->assertEquals('google.com', $route->getRawHost());
+        $this->assertSame('google.com', $route->getRawHost());
     }
 
     /**
@@ -344,7 +344,7 @@ class RouteTest extends \PHPUnit\Framework\TestCase
             'host' => 'google.com'
         ];
         $route = new Route('get', '/foo', 'foo@bar', $options);
-        $this->assertEquals('google.com', $route->getRawHost());
+        $this->assertSame('google.com', $route->getRawHost());
     }
 
     /**
@@ -354,7 +354,7 @@ class RouteTest extends \PHPUnit\Framework\TestCase
     {
         $route = new Route('get', '/{foo}', 'foo@bar');
         $route->setRawPath('blah');
-        $this->assertEquals('blah', $route->getRawPath());
+        $this->assertSame('blah', $route->getRawPath());
     }
 
     /**
@@ -365,7 +365,7 @@ class RouteTest extends \PHPUnit\Framework\TestCase
         $route = new Route('get', '/{foo}', 'foo@bar');
         $route->setVarRegex('foo', "\d+");
         $this->assertEquals(['foo' => "\d+"], $route->getVarRegexes());
-        $this->assertEquals("\d+", $route->getVarRegex('foo'));
+        $this->assertSame("\d+", $route->getVarRegex('foo'));
     }
 
     /**

--- a/src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php
+++ b/src/Opulence/Routing/Tests/Urls/UrlGeneratorTest.php
@@ -156,11 +156,11 @@ class UrlGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     public function testGeneratingHttpsUrl()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'https://foo.example.com/users',
             $this->generator->createFromName('secureHostNoParameters')
         );
-        $this->assertEquals(
+        $this->assertSame(
             '#^' . preg_quote('https://foo.example.com/users', '#') . '$#',
             $this->generator->createRegexFromName('secureHostNoParameters')
         );
@@ -172,7 +172,7 @@ class UrlGeneratorTest extends \PHPUnit\Framework\TestCase
     public function testGeneratingUrlForNonExistentRoute()
     {
         $this->assertEmpty($this->generator->createFromName('foo'));
-        $this->assertEquals('#^.*$#', $this->generator->createRegexFromName('foo'));
+        $this->assertSame('#^.*$#', $this->generator->createRegexFromName('foo'));
     }
 
     /**
@@ -180,11 +180,11 @@ class UrlGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     public function testGeneratingUrlWithMultipleHostAndPathValues()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'http://foo.bar.example.com/users/23/profile/edit',
             $this->generator->createFromName('hostAndPathMultipleParameters', 'foo', 'bar', 23, 'edit')
         );
-        $this->assertEquals(
+        $this->assertSame(
             "#^http\://(?P<subdomain1>[^\/:]+)\.(?P<subdomain2>[^\/:]+)\.example\.com/users/(?P<userId>[^\/:]+)/profile/(?P<mode>[^\/:]+)$#",
             $this->generator->createRegexFromName('hostAndPathMultipleParameters')
         );
@@ -195,10 +195,10 @@ class UrlGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     public function testGeneratingUrlWithNoValues()
     {
-        $this->assertEquals('/users', $this->generator->createFromName('pathNoParameters'));
-        $this->assertEquals('http://example.com/users', $this->generator->createFromName('hostNoParameters'));
-        $this->assertEquals('#^/users$#', $this->generator->createRegexFromName('pathNoParameters'));
-        $this->assertEquals("#^http\://example\.com/users$#",
+        $this->assertSame('/users', $this->generator->createFromName('pathNoParameters'));
+        $this->assertSame('http://example.com/users', $this->generator->createFromName('hostNoParameters'));
+        $this->assertSame('#^/users$#', $this->generator->createRegexFromName('pathNoParameters'));
+        $this->assertSame("#^http\://example\.com/users$#",
             $this->generator->createRegexFromName('hostNoParameters'));
     }
 
@@ -207,14 +207,14 @@ class UrlGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     public function testGeneratingUrlWithOneValue()
     {
-        $this->assertEquals('/users/23', $this->generator->createFromName('pathOneParameter', 23));
-        $this->assertEquals(
+        $this->assertSame('/users/23', $this->generator->createFromName('pathOneParameter', 23));
+        $this->assertSame(
             'http://foo.example.com/users',
             $this->generator->createFromName('hostOneParameter', 'foo')
         );
-        $this->assertEquals("#^/users/(?P<userId>[^\/:]+)$#",
+        $this->assertSame("#^/users/(?P<userId>[^\/:]+)$#",
             $this->generator->createRegexFromName('pathOneParameter'));
-        $this->assertEquals(
+        $this->assertSame(
             "#^http\://(?P<subdomain>[^\/:]+)\.example\.com/users$#",
             $this->generator->createRegexFromName('hostOneParameter')
         );
@@ -225,11 +225,11 @@ class UrlGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     public function testGeneratingUrlWithOptionalHostVariable()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'http://example.com/users',
             $this->generator->createFromName('hostOptionalVariable')
         );
-        $this->assertEquals(
+        $this->assertSame(
             "#^http\://(?:(?P<subdomain>[^\/:]+))?example\.com/users$#",
             $this->generator->createRegexFromName('hostOptionalVariable')
         );
@@ -240,15 +240,15 @@ class UrlGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     public function testGeneratingUrlWithOptionalNestedSlashesAndPathVariables()
     {
-        $this->assertEquals(
+        $this->assertSame(
             '/users',
             $this->generator->createFromName('pathOptionalNestedSlashesAndVariables')
         );
-        $this->assertEquals(
+        $this->assertSame(
             '/users/bar',
             $this->generator->createFromName('pathOptionalNestedSlashesAndVariables', 'bar')
         );
-        $this->assertEquals(
+        $this->assertSame(
             '/users/bar/baz',
             $this->generator->createFromName('pathOptionalNestedSlashesAndVariables', 'bar', 'baz')
         );
@@ -259,11 +259,11 @@ class UrlGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     public function testGeneratingUrlWithOptionalPathVariable()
     {
-        $this->assertEquals(
+        $this->assertSame(
             '/users',
             $this->generator->createFromName('pathOptionalVariable')
         );
-        $this->assertEquals(
+        $this->assertSame(
             "#^/users(?:(?P<foo>[^\/:]+))?$#",
             $this->generator->createRegexFromName('pathOptionalVariable')
         );
@@ -274,11 +274,11 @@ class UrlGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     public function testGeneratingUrlWithOptionalSlashAndPathVariable()
     {
-        $this->assertEquals(
+        $this->assertSame(
             '/users',
             $this->generator->createFromName('pathOptionalSlashAndVariable')
         );
-        $this->assertEquals(
+        $this->assertSame(
             '/users/bar',
             $this->generator->createFromName('pathOptionalSlashAndVariable', 'bar')
         );
@@ -289,7 +289,7 @@ class UrlGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     public function testGeneratingUrlWithOptionalVariablesInPathAndHost()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'http://example.com/users',
             $this->generator->createFromName('hostAndPathOptionalParameters')
         );
@@ -300,9 +300,9 @@ class UrlGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     public function testGeneratingUrlWithTwoValues()
     {
-        $this->assertEquals('/users/23/profile/edit',
+        $this->assertSame('/users/23/profile/edit',
             $this->generator->createFromName('pathTwoParameters', 23, 'edit'));
-        $this->assertEquals(
+        $this->assertSame(
             'http://foo.bar.example.com/users',
             $this->generator->createFromName('hostTwoParameters', 'foo', 'bar')
         );
@@ -340,6 +340,6 @@ class UrlGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     public function testPassingNonArrayValue()
     {
-        $this->assertEquals('/users/23', $this->generator->createFromName('pathOneParameter', 23));
+        $this->assertSame('/users/23', $this->generator->createFromName('pathOneParameter', 23));
     }
 }

--- a/src/Opulence/Sessions/Tests/Handlers/ArraySessionHandlerTest.php
+++ b/src/Opulence/Sessions/Tests/Handlers/ArraySessionHandlerTest.php
@@ -66,6 +66,6 @@ class ArraySessionHandlerTest extends \PHPUnit\Framework\TestCase
     public function testWritingSession()
     {
         $this->handler->write('foo', 'bar');
-        $this->assertEquals('bar', $this->handler->read('foo'));
+        $this->assertSame('bar', $this->handler->read('foo'));
     }
 }

--- a/src/Opulence/Sessions/Tests/Handlers/CacheSessionHandlerTest.php
+++ b/src/Opulence/Sessions/Tests/Handlers/CacheSessionHandlerTest.php
@@ -47,7 +47,7 @@ class CacheSessionHandlerTest extends \PHPUnit\Framework\TestCase
     public function testCacheGetIsCalledOnRead()
     {
         $this->bridge->expects($this->once())->method('get')->with('foo')->willReturn('bar');
-        $this->assertEquals('bar', $this->handler->read('foo'));
+        $this->assertSame('bar', $this->handler->read('foo'));
     }
 
     /**

--- a/src/Opulence/Sessions/Tests/Handlers/FileSessionHandlerTest.php
+++ b/src/Opulence/Sessions/Tests/Handlers/FileSessionHandlerTest.php
@@ -108,7 +108,7 @@ class FileSessionHandlerTest extends \PHPUnit\Framework\TestCase
     public function testReadingSession()
     {
         $this->fileSystem->write(__DIR__ . '/' . self::$path . '/foo', 'bar');
-        $this->assertEquals('bar', $this->handler->read('foo'));
+        $this->assertSame('bar', $this->handler->read('foo'));
     }
 
     /**
@@ -117,6 +117,6 @@ class FileSessionHandlerTest extends \PHPUnit\Framework\TestCase
     public function testWritingSession()
     {
         $this->handler->write('foo', 'bar');
-        $this->assertEquals('bar', $this->fileSystem->read(__DIR__ . '/' . self::$path . '/foo'));
+        $this->assertSame('bar', $this->fileSystem->read(__DIR__ . '/' . self::$path . '/foo'));
     }
 }

--- a/src/Opulence/Sessions/Tests/Handlers/SessionEncrypterTest.php
+++ b/src/Opulence/Sessions/Tests/Handlers/SessionEncrypterTest.php
@@ -69,7 +69,7 @@ class SessionEncrypterTest extends \PHPUnit\Framework\TestCase
             ->method('decrypt')
             ->with('foo')
             ->willReturn('bar');
-        $this->assertEquals('bar', $this->sessionEncrypter->decrypt('foo'));
+        $this->assertSame('bar', $this->sessionEncrypter->decrypt('foo'));
     }
 
     /**
@@ -81,6 +81,6 @@ class SessionEncrypterTest extends \PHPUnit\Framework\TestCase
             ->method('encrypt')
             ->with('foo')
             ->willReturn('bar');
-        $this->assertEquals('bar', $this->sessionEncrypter->encrypt('foo'));
+        $this->assertSame('bar', $this->sessionEncrypter->encrypt('foo'));
     }
 }

--- a/src/Opulence/Sessions/Tests/Handlers/SessionHandlerTest.php
+++ b/src/Opulence/Sessions/Tests/Handlers/SessionHandlerTest.php
@@ -77,7 +77,7 @@ class SessionHandlerTest extends \PHPUnit\Framework\TestCase
     public function testReadDataIsNotDecryptedWhenNotUsingEncrypter()
     {
         $this->handler->expects($this->any())->method('doRead')->will($this->returnValue('bar'));
-        $this->assertEquals('bar', $this->handler->read('foo'));
+        $this->assertSame('bar', $this->handler->read('foo'));
     }
 
     /**
@@ -89,7 +89,7 @@ class SessionHandlerTest extends \PHPUnit\Framework\TestCase
         $this->handler->setEncrypter($this->encrypter);
         $this->handler->expects($this->any())->method('doRead')->will($this->returnValue('foo'));
         $this->encrypter->expects($this->any())->method('decrypt')->will($this->returnValue('bar'));
-        $this->assertEquals('bar', $this->handler->read('baz'));
+        $this->assertSame('bar', $this->handler->read('baz'));
     }
 
     /**
@@ -102,7 +102,7 @@ class SessionHandlerTest extends \PHPUnit\Framework\TestCase
         $this->handler->expects($this->any())->method('doRead')->will($this->returnValue('foo'));
         $this->encrypter->expects($this->any())->method('decrypt')
             ->will($this->throwException(new SessionEncryptionException()));
-        $this->assertEquals(serialize([]), $this->handler->read('bar'));
+        $this->assertSame(serialize([]), $this->handler->read('bar'));
     }
 
     /**

--- a/src/Opulence/Sessions/Tests/Ids/Generators/IdGeneratorTest.php
+++ b/src/Opulence/Sessions/Tests/Ids/Generators/IdGeneratorTest.php
@@ -34,8 +34,8 @@ class IdGeneratorTest extends \PHPUnit\Framework\TestCase
     public function testGeneratingWithLength()
     {
         $id = $this->generator->generate(28);
-        $this->assertTrue(is_string($id));
-        $this->assertEquals(28, strlen($id));
+        $this->assertIsString($id);
+        $this->assertSame(28, strlen($id));
     }
 
     /**
@@ -44,8 +44,8 @@ class IdGeneratorTest extends \PHPUnit\Framework\TestCase
     public function testGeneratingWithoutLength()
     {
         $id = $this->generator->generate();
-        $this->assertTrue(is_string($id));
-        $this->assertEquals(IdGenerator::DEFAULT_LENGTH, strlen($id));
+        $this->assertIsString($id);
+        $this->assertSame(IdGenerator::DEFAULT_LENGTH, strlen($id));
     }
 
     /**

--- a/src/Opulence/Sessions/Tests/SessionTest.php
+++ b/src/Opulence/Sessions/Tests/SessionTest.php
@@ -36,7 +36,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
             $session->getAll()
         );
         $session->ageFlashData();
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertTrue($session->has('foo'));
         $this->assertEquals(
             [
@@ -50,7 +50,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $session->ageFlashData();
         $this->assertNull($session->get('foo'));
         $this->assertFalse($session->has('foo'));
-        $this->assertEquals('blah', $session->get('baz'));
+        $this->assertSame('blah', $session->get('baz'));
         $this->assertEquals(
             [
                 'baz' => 'blah',
@@ -83,7 +83,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $session->flash('foo', 'baz');
         $session->ageFlashData();
         $this->assertTrue($session->has('foo'));
-        $this->assertEquals('baz', $session->get('foo'));
+        $this->assertSame('baz', $session->get('foo'));
         $this->assertEquals(
             [
                 'foo' => 'baz',
@@ -137,7 +137,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $session = new Session();
         $session->flash('foo', 'bar');
         $this->assertTrue($session->has('foo'));
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertEquals(
             [
                 'foo' => 'bar',
@@ -180,7 +180,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $idGenerator = $this->createMock(IIdGenerator::class);
         $idGenerator->expects($this->any())->method('idIsValid')->willReturn(true);
         $session = new Session($id, $idGenerator);
-        $this->assertEquals($id, $session->getId());
+        $this->assertSame($id, $session->getId());
     }
 
     /**
@@ -199,7 +199,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
     public function testGettingNonExistentVariableWithDefaultValue()
     {
         $session = new Session();
-        $this->assertEquals('bar', $session->get('foo', 'bar'));
+        $this->assertSame('bar', $session->get('foo', 'bar'));
     }
 
     /**
@@ -212,7 +212,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $session->ageFlashData();
         $session->reflash();
         $this->assertTrue($session->has('foo'));
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertEquals(
             [
                 'foo' => 'bar',
@@ -223,7 +223,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         );
         $session->ageFlashData();
         $this->assertTrue($session->has('foo'));
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertEquals(
             [
                 'foo' => 'bar',
@@ -257,7 +257,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $idGenerator->expects($this->any())->method('generate')->willReturn($generatedId);
         $session = new Session(null, $idGenerator);
         $session->regenerateId();
-        $this->assertEquals($generatedId, $session->getId());
+        $this->assertSame($generatedId, $session->getId());
     }
 
     /**
@@ -267,8 +267,8 @@ class SessionTest extends \PHPUnit\Framework\TestCase
     {
         $session = new Session();
         $session->regenerateId();
-        $this->assertTrue(is_string($session->getId()));
-        $this->assertEquals(IdGenerator::DEFAULT_LENGTH, strlen($session->getId()));
+        $this->assertIsString($session->getId());
+        $this->assertSame(IdGenerator::DEFAULT_LENGTH, strlen($session->getId()));
     }
 
     /**
@@ -278,7 +278,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
     {
         $session = new Session();
         $session->setName('foo');
-        $this->assertEquals('foo', $session->getName());
+        $this->assertSame('foo', $session->getName());
     }
 
     /**
@@ -292,7 +292,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $session = new Session($constructorId, $idGenerator);
         $setterId = str_repeat(2, IIdGenerator::MIN_LENGTH);
         $session->setId($setterId);
-        $this->assertEquals($setterId, $session->getId());
+        $this->assertSame($setterId, $session->getId());
     }
 
     /**
@@ -342,8 +342,8 @@ class SessionTest extends \PHPUnit\Framework\TestCase
     {
         $session = new Session();
         $session['foo'] = 'bar';
-        $this->assertEquals('bar', $session['foo']);
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session['foo']);
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertEquals(['foo' => 'bar'], $session->getAll());
     }
 
@@ -354,7 +354,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
     {
         $session = new Session();
         $session->set('foo', 'bar');
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertEquals(['foo' => 'bar'], $session->getAll());
     }
 
@@ -366,8 +366,8 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $variables = ['foo' => 'bar', 'baz' => 'blah'];
         $session = new Session();
         $session->start($variables);
-        $this->assertEquals('bar', $session['foo']);
-        $this->assertEquals('blah', $session['baz']);
+        $this->assertSame('bar', $session['foo']);
+        $this->assertSame('blah', $session['baz']);
         $this->assertTrue($session->hasStarted());
     }
 
@@ -386,7 +386,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
     public function testUnsetNameIsEmptyString()
     {
         $session = new Session();
-        $this->assertEquals('', $session->getName());
+        $this->assertSame('', $session->getName());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/AlphaNumericRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/AlphaNumericRuleTest.php
@@ -34,7 +34,7 @@ class AlphaNumericRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new AlphaNumericRule();
-        $this->assertEquals('alphaNumeric', $rule->getSlug());
+        $this->assertSame('alphaNumeric', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/AlphaRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/AlphaRuleTest.php
@@ -34,7 +34,7 @@ class AlphaRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new AlphaRule();
-        $this->assertEquals('alpha', $rule->getSlug());
+        $this->assertSame('alpha', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/BetweenRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/BetweenRuleTest.php
@@ -46,7 +46,7 @@ class BetweenRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new BetweenRule();
-        $this->assertEquals('between', $rule->getSlug());
+        $this->assertSame('between', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/CallbackRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/CallbackRuleTest.php
@@ -61,7 +61,7 @@ class CallbackRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new CallbackRule();
-        $this->assertEquals('callback', $rule->getSlug());
+        $this->assertSame('callback', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/ConditionalRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/ConditionalRuleTest.php
@@ -45,7 +45,7 @@ class ConditionalRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new ConditionalRule();
-        $this->assertEquals('conditional', $rule->getSlug());
+        $this->assertSame('conditional', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/DateRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/DateRuleTest.php
@@ -39,7 +39,7 @@ class DateRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new DateRule();
-        $this->assertEquals('date', $rule->getSlug());
+        $this->assertSame('date', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/EmailRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/EmailRuleTest.php
@@ -23,7 +23,7 @@ class EmailRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new EmailRule();
-        $this->assertEquals('email', $rule->getSlug());
+        $this->assertSame('email', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/EqualsFieldRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/EqualsFieldRuleTest.php
@@ -45,7 +45,7 @@ class EqualsFieldRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new EqualsFieldRule();
-        $this->assertEquals('equalsField', $rule->getSlug());
+        $this->assertSame('equalsField', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/EqualsRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/EqualsRuleTest.php
@@ -34,7 +34,7 @@ class EqualsRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new EqualsRule();
-        $this->assertEquals('equals', $rule->getSlug());
+        $this->assertSame('equals', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/Errors/Compilers/CompilerTest.php
+++ b/src/Opulence/Validation/Tests/Rules/Errors/Compilers/CompilerTest.php
@@ -33,7 +33,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
      */
     public function testCompilingTemplateWithArgPlaceholders()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'foo dave baz young',
             $this->compiler->compile(
                 'foo',
@@ -48,7 +48,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
      */
     public function testCompilingTemplateWithArgPlaceholdersNotInSameOrderAsArgs()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'foo dave baz young',
             $this->compiler->compile(
                 'foo',
@@ -63,7 +63,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
      */
     public function testCompilingTemplateWithFieldAndArgPlaceholders()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'foo the-field dave baz young',
             $this->compiler->compile(
                 'the-field',
@@ -78,7 +78,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
      */
     public function testCompilingTemplateWithFieldPlaceholder()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'foo bar',
             $this->compiler->compile('foo', ':field bar')
         );
@@ -89,7 +89,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
      */
     public function testCompilingTemplateWithLeftoverPlaceholders()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'foo dave',
             $this->compiler->compile('foo',
                 'foo :bar :baz',
@@ -103,7 +103,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
      */
     public function testCompilingTemplateWithNoPlaceholders()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'foo bar',
             $this->compiler->compile('foo', 'foo bar')
         );

--- a/src/Opulence/Validation/Tests/Rules/Errors/ErrorCollectionTest.php
+++ b/src/Opulence/Validation/Tests/Rules/Errors/ErrorCollectionTest.php
@@ -34,7 +34,7 @@ class ErrorCollectionTest extends \PHPUnit\Framework\TestCase
     public function testAdding()
     {
         $this->collection->add('foo', 'bar');
-        $this->assertEquals('bar', $this->collection->get('foo'));
+        $this->assertSame('bar', $this->collection->get('foo'));
     }
 
     /**
@@ -52,9 +52,9 @@ class ErrorCollectionTest extends \PHPUnit\Framework\TestCase
     public function testCount()
     {
         $this->collection->add('foo', 'bar');
-        $this->assertEquals(1, $this->collection->count());
+        $this->assertSame(1, $this->collection->count());
         $this->collection->add('bar', 'foo');
-        $this->assertEquals(2, $this->collection->count());
+        $this->assertSame(2, $this->collection->count());
     }
 
     /**
@@ -73,7 +73,7 @@ class ErrorCollectionTest extends \PHPUnit\Framework\TestCase
     public function testGetting()
     {
         $this->collection->add('foo', 'bar');
-        $this->assertEquals('bar', $this->collection->get('foo'));
+        $this->assertSame('bar', $this->collection->get('foo'));
     }
 
     /**
@@ -81,7 +81,7 @@ class ErrorCollectionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingAbsentVariableWithDefault()
     {
-        $this->assertEquals('blah', $this->collection->get('does not exist', 'blah'));
+        $this->assertSame('blah', $this->collection->get('does not exist', 'blah'));
     }
 
     /**
@@ -111,7 +111,7 @@ class ErrorCollectionTest extends \PHPUnit\Framework\TestCase
     public function testGettingAsArray()
     {
         $this->collection->add('foo', 'bar');
-        $this->assertEquals('bar', $this->collection['foo']);
+        $this->assertSame('bar', $this->collection['foo']);
     }
 
     /**
@@ -150,7 +150,7 @@ class ErrorCollectionTest extends \PHPUnit\Framework\TestCase
     public function testSetting()
     {
         $this->collection->set('foo', 'bar');
-        $this->assertEquals('bar', $this->collection->get('foo'));
+        $this->assertSame('bar', $this->collection->get('foo'));
     }
 
     /**
@@ -159,7 +159,7 @@ class ErrorCollectionTest extends \PHPUnit\Framework\TestCase
     public function testSettingItem()
     {
         $this->collection['foo'] = 'bar';
-        $this->assertEquals('bar', $this->collection['foo']);
+        $this->assertSame('bar', $this->collection['foo']);
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/Errors/ErrorTemplateRegistryTest.php
+++ b/src/Opulence/Validation/Tests/Rules/Errors/ErrorTemplateRegistryTest.php
@@ -34,7 +34,7 @@ class ErrorTemplateRegistryTest extends \PHPUnit\Framework\TestCase
      */
     public function testEmptyStringReturnedWhenNoTemplateExists()
     {
-        $this->assertEquals('', $this->registry->getErrorTemplate('foo', 'bar'));
+        $this->assertSame('', $this->registry->getErrorTemplate('foo', 'bar'));
     }
 
     /**
@@ -62,7 +62,7 @@ class ErrorTemplateRegistryTest extends \PHPUnit\Framework\TestCase
     {
         $this->registry->registerFieldErrorTemplate('field', 'foo', 'field template');
         $this->registry->registerGlobalErrorTemplate('foo', 'global template');
-        $this->assertEquals('field template', $this->registry->getErrorTemplate('field', 'foo'));
+        $this->assertSame('field template', $this->registry->getErrorTemplate('field', 'foo'));
     }
 
     /**
@@ -74,7 +74,7 @@ class ErrorTemplateRegistryTest extends \PHPUnit\Framework\TestCase
             'field.foo' => 'field template',
             'foo' => 'global template'
         ]);
-        $this->assertEquals('field template', $this->registry->getErrorTemplate('field', 'foo'));
+        $this->assertSame('field template', $this->registry->getErrorTemplate('field', 'foo'));
     }
 
     /**
@@ -84,7 +84,7 @@ class ErrorTemplateRegistryTest extends \PHPUnit\Framework\TestCase
     {
         $this->registry->registerGlobalErrorTemplate('foo', 'template 1');
         $this->registry->registerGlobalErrorTemplate('foo', 'template 2');
-        $this->assertEquals('template 2', $this->registry->getErrorTemplate('field', 'foo'));
+        $this->assertSame('template 2', $this->registry->getErrorTemplate('field', 'foo'));
     }
 
     /**
@@ -93,7 +93,7 @@ class ErrorTemplateRegistryTest extends \PHPUnit\Framework\TestCase
     public function testRegisteringFieldTemplate()
     {
         $this->registry->registerFieldErrorTemplate('field', 'foo', 'bar baz');
-        $this->assertEquals('bar baz', $this->registry->getErrorTemplate('field', 'foo'));
+        $this->assertSame('bar baz', $this->registry->getErrorTemplate('field', 'foo'));
     }
 
     /**
@@ -104,7 +104,7 @@ class ErrorTemplateRegistryTest extends \PHPUnit\Framework\TestCase
         $this->registry->registerErrorTemplatesFromConfig([
             'field.foo' => 'field template'
         ]);
-        $this->assertEquals('field template', $this->registry->getErrorTemplate('field', 'foo'));
+        $this->assertSame('field template', $this->registry->getErrorTemplate('field', 'foo'));
     }
 
     /**
@@ -113,7 +113,7 @@ class ErrorTemplateRegistryTest extends \PHPUnit\Framework\TestCase
     public function testRegisteringGlobalTemplate()
     {
         $this->registry->registerGlobalErrorTemplate('foo', 'bar baz');
-        $this->assertEquals('bar baz', $this->registry->getErrorTemplate('field', 'foo'));
+        $this->assertSame('bar baz', $this->registry->getErrorTemplate('field', 'foo'));
     }
 
     /**
@@ -124,6 +124,6 @@ class ErrorTemplateRegistryTest extends \PHPUnit\Framework\TestCase
         $this->registry->registerErrorTemplatesFromConfig([
             'foo' => 'global template'
         ]);
-        $this->assertEquals('global template', $this->registry->getErrorTemplate('field', 'foo'));
+        $this->assertSame('global template', $this->registry->getErrorTemplate('field', 'foo'));
     }
 }

--- a/src/Opulence/Validation/Tests/Rules/IPAddressRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/IPAddressRuleTest.php
@@ -33,7 +33,7 @@ class IPAddressRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new IPAddressRule();
-        $this->assertEquals('ipAddress', $rule->getSlug());
+        $this->assertSame('ipAddress', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/InRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/InRuleTest.php
@@ -25,7 +25,7 @@ class InRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new InRule();
-        $this->assertEquals('in', $rule->getSlug());
+        $this->assertSame('in', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/IntegerRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/IntegerRuleTest.php
@@ -35,7 +35,7 @@ class IntegerRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new IntegerRule();
-        $this->assertEquals('integer', $rule->getSlug());
+        $this->assertSame('integer', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/MaxRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/MaxRuleTest.php
@@ -46,7 +46,7 @@ class MaxRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new MaxRule();
-        $this->assertEquals('max', $rule->getSlug());
+        $this->assertSame('max', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/MinRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/MinRuleTest.php
@@ -46,7 +46,7 @@ class MinRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new MinRule();
-        $this->assertEquals('min', $rule->getSlug());
+        $this->assertSame('min', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/NotInRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/NotInRuleTest.php
@@ -25,7 +25,7 @@ class NotInRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new NotInRule();
-        $this->assertEquals('notIn', $rule->getSlug());
+        $this->assertSame('notIn', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/NumericRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/NumericRuleTest.php
@@ -33,7 +33,7 @@ class NumericRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new NumericRule();
-        $this->assertEquals('numeric', $rule->getSlug());
+        $this->assertSame('numeric', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/RegexRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/RegexRuleTest.php
@@ -25,7 +25,7 @@ class RegexRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new RegexRule();
-        $this->assertEquals('regex', $rule->getSlug());
+        $this->assertSame('regex', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Validation/Tests/Rules/RequiredRuleTest.php
+++ b/src/Opulence/Validation/Tests/Rules/RequiredRuleTest.php
@@ -38,7 +38,7 @@ class RequiredRuleTest extends \PHPUnit\Framework\TestCase
     public function testGettingSlug()
     {
         $rule = new RequiredRule();
-        $this->assertEquals('required', $rule->getSlug());
+        $this->assertSame('required', $rule->getSlug());
     }
 
     /**

--- a/src/Opulence/Views/Tests/Caching/ArrayCacheTest.php
+++ b/src/Opulence/Views/Tests/Caching/ArrayCacheTest.php
@@ -49,7 +49,7 @@ class ArrayCacheTest extends \PHPUnit\Framework\TestCase
     public function testGettingExistingView()
     {
         $this->cache->set($this->view, 'foo');
-        $this->assertEquals('foo', $this->cache->get($this->view));
+        $this->assertSame('foo', $this->cache->get($this->view));
         $this->assertTrue($this->cache->has($this->view));
     }
 
@@ -82,8 +82,8 @@ class ArrayCacheTest extends \PHPUnit\Framework\TestCase
             ->method('getVars')
             ->willReturn(['bar' => 'blah']);
         $this->cache->set($view1, 'content');
-        $this->assertEquals('content', $this->cache->get($view1));
-        $this->assertEquals('content', $this->cache->get($view2));
+        $this->assertSame('content', $this->cache->get($view1));
+        $this->assertSame('content', $this->cache->get($view2));
         $this->assertTrue($this->cache->has($view1));
         $this->assertTrue($this->cache->has($view2));
     }

--- a/src/Opulence/Views/Tests/Caching/FileCacheTest.php
+++ b/src/Opulence/Views/Tests/Caching/FileCacheTest.php
@@ -81,7 +81,7 @@ class FileCacheTest extends \PHPUnit\Framework\TestCase
         $this->setViewContentsAndVars('foo', ['bar' => 'baz']);
         $this->cache->set($this->view, 'compiled', true);
         $this->assertTrue($this->cache->has($this->view, true));
-        $this->assertEquals('compiled', $this->cache->get($this->view, true));
+        $this->assertSame('compiled', $this->cache->get($this->view, true));
     }
 
     /**

--- a/src/Opulence/Views/Tests/Compilers/Fortune/DirectiveTranspilerRegistrantTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Fortune/DirectiveTranspilerRegistrantTest.php
@@ -51,7 +51,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingElse()
     {
         $this->view->setContents('<% else %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php else: ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -63,7 +63,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingElseIf()
     {
         $this->view->setContents('<% elseif(true) %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php elseif(true): ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -75,7 +75,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingEndFor()
     {
         $this->view->setContents('<% endfor %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php endfor; ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -87,7 +87,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingEndForeach()
     {
         $this->view->setContents('<% endforeach %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php endforeach; ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -99,7 +99,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingEndIf()
     {
         $this->view->setContents('<% endif %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php endif; ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -111,7 +111,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingEndPart()
     {
         $this->view->setContents('<% endpart %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php $__opulenceFortuneTranspiler->endPart(); ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -123,7 +123,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingEndWhile()
     {
         $this->view->setContents('<% endwhile %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php endwhile; ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -141,7 +141,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
             'bar',
             '<?php echo eval("?>" . array_shift($__opulenceParentContents)); ?>'
         ];
-        $this->assertEquals(
+        $this->assertSame(
             implode(PHP_EOL, $expected),
             $this->transpiler->transpile($this->view)
         );
@@ -153,7 +153,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingFor()
     {
         $this->view->setContents('<% for($i=0;$i<10;$i++) %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php for($i=0;$i<10;$i++): ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -165,7 +165,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingForElse()
     {
         $this->view->setContents('<% forelse %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php endforeach; if(array_pop($__opulenceForElseEmpty)): ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -177,7 +177,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingForIf()
     {
         $this->view->setContents('<% forif($foo as $bar) %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php if(!isset($__opulenceForElseEmpty)): $__opulenceForElseEmpty = []; endif;$__opulenceForElseEmpty[] = true;' .
             'foreach($foo as $bar):' .
             '$__opulenceForElseEmpty[count($__opulenceForElseEmpty) - 1] = false; ?>',
@@ -191,7 +191,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingForeach()
     {
         $this->view->setContents('<% foreach($foo as $bar) %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php foreach($foo as $bar): ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -203,7 +203,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingIf()
     {
         $this->view->setContents('<% if(true) %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php if(true): ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -222,7 +222,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
         $code .= 'eval("?>" . $__opulenceFortuneTranspiler->transpile($__opulenceIncludedView));';
         $code .= '}, []);';
         $code .= ' ?>';
-        $this->assertEquals(
+        $this->assertSame(
             "{$code}bar",
             $this->transpiler->transpile($this->view)
         );
@@ -241,7 +241,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
         $code .= 'eval("?>" . $__opulenceFortuneTranspiler->transpile($__opulenceIncludedView));';
         $code .= '}, ["foo" => "bar"]);';
         $code .= ' ?>';
-        $this->assertEquals(
+        $this->assertSame(
             "{$code}baz",
             $this->transpiler->transpile($this->view)
         );
@@ -260,7 +260,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
         $code .= 'eval("?>" . $__opulenceFortuneTranspiler->transpile($__opulenceIncludedView));';
         $code .= '}, compact("foo", "bar"));';
         $code .= ' ?>';
-        $this->assertEquals(
+        $this->assertSame(
             "{$code}baz",
             $this->transpiler->transpile($this->view)
         );
@@ -279,7 +279,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
         $code .= 'eval("?>" . $__opulenceFortuneTranspiler->transpile($__opulenceIncludedView));';
         $code .= '}, ["foo" => "bar"]);';
         $code .= ' ?>';
-        $this->assertEquals(
+        $this->assertSame(
             "{$code}baz",
             $this->transpiler->transpile($this->view)
         );
@@ -291,7 +291,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingParent()
     {
         $this->view->setContents('<% parent %>');
-        $this->assertEquals(
+        $this->assertSame(
             '__opulenceParentPlaceholder',
             $this->transpiler->transpile($this->view)
         );
@@ -303,7 +303,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingPart()
     {
         $this->view->setContents('<% part("foo") %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php $__opulenceFortuneTranspiler->startPart("foo"); ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -315,7 +315,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingShow()
     {
         $this->view->setContents('<% show("foo") %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php echo $__opulenceFortuneTranspiler->showPart("foo"); ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -327,7 +327,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingShowWithoutExpression()
     {
         $this->view->setContents('<% show %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php echo $__opulenceFortuneTranspiler->showPart(); ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -339,7 +339,7 @@ class DirectiveTranspilerRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTranspilingWhile()
     {
         $this->view->setContents('<% while(true) %>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php while(true): ?>',
             $this->transpiler->transpile($this->view)
         );

--- a/src/Opulence/Views/Tests/Compilers/Fortune/FortuneCompilerTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Fortune/FortuneCompilerTest.php
@@ -70,7 +70,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
             ->with('Foo')
             ->willReturn($parentView);
         $this->view->setContents('<% extends("Foo") %>{{$foo}}');
-        $this->assertEquals(
+        $this->assertSame(
             'bar',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -85,7 +85,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
             return "foo: $input";
         });
         $this->view->setContents('{{!foo("bar")!}}');
-        $this->assertEquals('foo: bar', $this->fortuneCompiler->compile($this->view));
+        $this->assertSame('foo: bar', $this->fortuneCompiler->compile($this->view));
     }
 
     /**
@@ -94,12 +94,12 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
     public function testCompilingElseIfStatement()
     {
         $this->view->setContents('<% if(false) %>foo<% elseif(false) %>bar<% endif %>');
-        $this->assertEquals(
+        $this->assertSame(
             '',
             $this->fortuneCompiler->compile($this->view)
         );
         $this->view->setContents('<% if(false) %>foo<% elseif(true) %>bar<% endif %>');
-        $this->assertEquals(
+        $this->assertSame(
             'bar',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -111,7 +111,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
     public function testCompilingElseStatement()
     {
         $this->view->setContents('<% if(false) %>foo<% else %>bar<% endif %>');
-        $this->assertEquals(
+        $this->assertSame(
             'bar',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -123,7 +123,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
     public function testCompilingEscapedStructures()
     {
         $this->view->setContents('\{{foo}}\{{!bar!}}\<% baz %>');
-        $this->assertEquals(
+        $this->assertSame(
             '{{foo}}{{!bar!}}<% baz %>',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -135,12 +135,12 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
     public function testCompilingForIfLoop()
     {
         $this->view->setContents('<% forif([0, 1] as $item) %>{{$item}}<% forelse %>empty<% endif %>');
-        $this->assertEquals(
+        $this->assertSame(
             '01',
             $this->fortuneCompiler->compile($this->view)
         );
         $this->view->setContents('<% forif([] as $item) %>{{$item}}<% forelse %>empty<% endif %>');
-        $this->assertEquals(
+        $this->assertSame(
             'empty',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -152,7 +152,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
     public function testCompilingForLoop()
     {
         $this->view->setContents('<% for($i=0;$i<2;$i++) %><?php echo $i; ?><% endfor %>');
-        $this->assertEquals(
+        $this->assertSame(
             '01',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -164,7 +164,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
     public function testCompilingForeachLoop()
     {
         $this->view->setContents('<% foreach([0, 1] as $item) %><?php echo $item; ?><% endforeach %>');
-        $this->assertEquals(
+        $this->assertSame(
             '01',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -176,12 +176,12 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
     public function testCompilingIfStatement()
     {
         $this->view->setContents('<% if(false) %>foo<% endif %>');
-        $this->assertEquals(
+        $this->assertSame(
             '',
             $this->fortuneCompiler->compile($this->view)
         );
         $this->view->setContents('<% if(true) %>foo<% endif %>');
-        $this->assertEquals(
+        $this->assertSame(
             'foo',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -197,7 +197,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
             ->method('createView')
             ->willReturn($includedView);
         $this->view->setContents('<% include("Foo") %>bar');
-        $this->assertEquals(
+        $this->assertSame(
             'foobar',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -209,17 +209,17 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
     public function testCompilingNestedForIfLoops()
     {
         $this->view->setContents('<% forif([0, 1] as $x) %><% forif([2, 3] as $y) %>{{$x}}{{$y}}<% forelse %>empty2<% endif %><% forelse %>empty1<% endif %>');
-        $this->assertEquals(
+        $this->assertSame(
             '02031213',
             $this->fortuneCompiler->compile($this->view)
         );
         $this->view->setContents('<% forif([] as $x) %><% forif([] as $y) %>{{$x}}{{$y}}<% forelse %>empty2<% endif %><% forelse %>empty1<% endif %>');
-        $this->assertEquals(
+        $this->assertSame(
             'empty1',
             $this->fortuneCompiler->compile($this->view)
         );
         $this->view->setContents('<% forif([0, 1] as $x) %><% forif([] as $y) %>{{$x}}{{$y}}<% forelse %>empty2<% endif %><% forelse %>empty1<% endif %>');
-        $this->assertEquals(
+        $this->assertSame(
             'empty2empty2',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -239,7 +239,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
             ->method('createView')
             ->willReturn($includedView2);
         $this->view->setContents('<% include("Foo") %>baz');
-        $this->assertEquals(
+        $this->assertSame(
             'foobarbaz',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -261,7 +261,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
             ->with('Foo')
             ->willReturn($parent1);
         $this->view->setContents('<% extends("Bar") %><% part("foo") %><% parent %>blah<% endpart %>');
-        $this->assertEquals(
+        $this->assertSame(
             'barbazblah',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -278,7 +278,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
             ->with('Foo')
             ->willReturn($parentView);
         $this->view->setContents('<% extends("Foo") %><% part("foo") %><% parent %>baz<% endpart %>');
-        $this->assertEquals(
+        $this->assertSame(
             'barbaz',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -290,17 +290,17 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
     public function testCompilingPartAndShowStatements()
     {
         $this->view->setContents('<% part("a") %>foo<% endpart %>');
-        $this->assertEquals(
+        $this->assertSame(
             '',
             $this->fortuneCompiler->compile($this->view)
         );
         $this->view->setContents('<% part("a") %>foo<% endpart %><% show("a") %>');
-        $this->assertEquals(
+        $this->assertSame(
             'foo',
             $this->fortuneCompiler->compile($this->view)
         );
         $this->view->setContents('<% part("a") %>foo<% show %>');
-        $this->assertEquals(
+        $this->assertSame(
             'foo',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -329,7 +329,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
     public function testCompilingWhileLoop()
     {
         $this->view->setContents('<?php $i = 0; ?><% while($i < 2) %>{{$i}}<?php $i++; ?><% endwhile %>');
-        $this->assertEquals(
+        $this->assertSame(
             '01',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -346,7 +346,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
             ->method('createView')
             ->willReturn($includedView);
         $this->view->setContents('<% include("Foo") %><?php echo isset($foo) ? "set" : "not set"; ?>');
-        $this->assertEquals(
+        $this->assertSame(
             'foonot set',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -363,7 +363,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
             ->willReturn($includedView);
         $this->view->setContents('<% include("Foo") %>');
         $this->view->setVar('foo', 'bar');
-        $this->assertEquals(
+        $this->assertSame(
             'not set',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -375,7 +375,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
     public function testLineBreaksAreTrimmedAfterCompiling()
     {
         $this->view->setContents(PHP_EOL . PHP_EOL . "\r\nfoo\r\n" . PHP_EOL . PHP_EOL);
-        $this->assertEquals('foo', $this->fortuneCompiler->compile($this->view));
+        $this->assertSame('foo', $this->fortuneCompiler->compile($this->view));
     }
 
     /**
@@ -394,7 +394,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
             ->with('Grandparent')
             ->willReturn($grandparentView);
         $this->view->setContents('<% extends("Parent") %><% part("foo") %>blah<% endpart %>');
-        $this->assertEquals(
+        $this->assertSame(
             'blah',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -418,7 +418,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
             ->willReturn($grandparentView);
         $this->view->setContents('<% extends("Parent") %>');
         $this->view->setVar('foo', 'baz');
-        $this->assertEquals(
+        $this->assertSame(
             'baz',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -437,7 +437,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
             ->willReturn($parentView);
         $this->view->setContents('<% extends("Foo") %>');
         $this->view->setVar('foo', 'baz');
-        $this->assertEquals(
+        $this->assertSame(
             'baz',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -454,7 +454,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
             ->with('Foo')
             ->willReturn($includedView);
         $this->view->setContents('<% extends("Foo") %><% part("foo") %>baz<% endpart %>');
-        $this->assertEquals(
+        $this->assertSame(
             'baz',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -467,7 +467,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
     {
         $this->view->setContents('<?php echo $foo; ?>');
         $this->view->setVar('foo', '<?php exit; ?>');
-        $this->assertEquals(
+        $this->assertSame(
             '<?php exit; ?>',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -484,7 +484,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
             ->method('createView')
             ->willReturn($includedView);
         $this->view->setContents('<% include("Foo", ["foo" => "baz"]) %>bar');
-        $this->assertEquals(
+        $this->assertSame(
             'bazbar',
             $this->fortuneCompiler->compile($this->view)
         );
@@ -505,7 +505,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
         $viewFactory = $this->createMock(IViewFactory::class);
         $this->view->setContents('foo');
         $compiler = new FortuneCompiler($transpiler, $viewFactory);
-        $this->assertEquals('bar', $compiler->compile($this->view));
+        $this->assertSame('bar', $compiler->compile($this->view));
         $this->assertSame($viewFactory, $this->view->getVar('__opulenceViewFactory'));
         $this->assertSame($transpiler, $this->view->getVar('__opulenceFortuneTranspiler'));
     }
@@ -516,7 +516,7 @@ class FortuneCompilerTest extends \PHPUnit\Framework\TestCase
     public function testViewCommentsAreNotDisplayed()
     {
         $this->view->setContents('{# Testing #}');
-        $this->assertEquals('', $this->fortuneCompiler->compile($this->view));
+        $this->assertSame('', $this->fortuneCompiler->compile($this->view));
     }
 
     /**

--- a/src/Opulence/Views/Tests/Compilers/Fortune/Lexers/Tokens/TokenTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Fortune/Lexers/Tokens/TokenTest.php
@@ -34,7 +34,7 @@ class TokenTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingLine()
     {
-        $this->assertEquals(1, $this->token->getLine());
+        $this->assertSame(1, $this->token->getLine());
     }
 
     /**
@@ -42,7 +42,7 @@ class TokenTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingType()
     {
-        $this->assertEquals(TokenTypes::T_EXPRESSION, $this->token->getType());
+        $this->assertSame(TokenTypes::T_EXPRESSION, $this->token->getType());
     }
 
     /**
@@ -50,6 +50,6 @@ class TokenTest extends \PHPUnit\Framework\TestCase
      */
     public function testGettingValue()
     {
-        $this->assertEquals('foo', $this->token->getValue());
+        $this->assertSame('foo', $this->token->getValue());
     }
 }

--- a/src/Opulence/Views/Tests/Compilers/Fortune/Parsers/Nodes/NodeTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Fortune/Parsers/Nodes/NodeTest.php
@@ -66,6 +66,6 @@ class NodeTest extends \PHPUnit\Framework\TestCase
     {
         /** @var Node $node */
         $node = $this->getMockForAbstractClass(Node::class, ['foo']);
-        $this->assertEquals('foo', $node->getValue());
+        $this->assertSame('foo', $node->getValue());
     }
 }

--- a/src/Opulence/Views/Tests/Compilers/Fortune/TranspilerTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Fortune/TranspilerTest.php
@@ -76,7 +76,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
             ->addChild(new ExpressionNode('<?php'))
             ->addChild(new ExpressionNode('echo "foo";'))
             ->addChild(new ExpressionNode('?>'));
-        $this->assertEquals(
+        $this->assertSame(
             '<?php echo "foo"; ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -99,7 +99,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
             ->method('get')
             ->with($view)
             ->willReturn('transpiled');
-        $this->assertEquals('transpiled', $this->transpiler->transpile($view));
+        $this->assertSame('transpiled', $this->transpiler->transpile($view));
     }
 
     /**
@@ -110,7 +110,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
         $this->transpiler->registerViewFunction('foo', function () {
             return 'foobar';
         });
-        $this->assertEquals('foobar', $this->transpiler->callViewFunction('foo'));
+        $this->assertSame('foobar', $this->transpiler->callViewFunction('foo'));
     }
 
     /**
@@ -121,7 +121,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
         $this->transpiler->registerViewFunction('foo', function ($input) {
             return 'foo' . $input;
         });
-        $this->assertEquals('foobar', $this->transpiler->callViewFunction('foo', 'bar'));
+        $this->assertSame('foobar', $this->transpiler->callViewFunction('foo', 'bar'));
     }
 
     /**
@@ -132,7 +132,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
         $this->transpiler->startPart('foo');
         echo 'bar';
         $this->transpiler->endPart();
-        $this->assertEquals('bar', $this->transpiler->showPart('foo'));
+        $this->assertSame('bar', $this->transpiler->showPart('foo'));
     }
 
     /**
@@ -190,7 +190,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
         $this->transpiler->addParent($parent1, $child);
         $this->transpiler->addParent($parent2, $child);
         $this->transpiler->transpile($child);
-        $this->assertEquals('bar', $child->getVar('foo'));
+        $this->assertSame('bar', $child->getVar('foo'));
     }
 
     /**
@@ -247,7 +247,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
         $directiveNode->addChild(new ExpressionNode('bar'));
         $this->ast->getCurrentNode()
             ->addChild($directiveNode);
-        $this->assertEquals(
+        $this->assertSame(
             '<?php foo bar ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -259,7 +259,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
     public function testSanitizingText()
     {
         $text = 'A&W"\'';
-        $this->assertEquals($this->xssFilter->run($text), $this->transpiler->sanitize($text));
+        $this->assertSame($this->xssFilter->run($text), $this->transpiler->sanitize($text));
     }
 
     /**
@@ -269,7 +269,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
     {
         $this->transpiler->startPart('foo');
         echo 'bar';
-        $this->assertEquals('bar', $this->transpiler->showPart());
+        $this->assertSame('bar', $this->transpiler->showPart());
     }
 
     /**
@@ -284,7 +284,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
         $this->transpiler->startPart('foo');
         echo 'bar';
         $this->transpiler->endPart();
-        $this->assertEquals('barbaz', $this->transpiler->showPart('foo'));
+        $this->assertSame('barbaz', $this->transpiler->showPart('foo'));
     }
 
     /**
@@ -303,7 +303,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
         $this->transpiler->startPart('foo');
         echo 'blah';
         $this->transpiler->endPart();
-        $this->assertEquals('blahbarbaz', $this->transpiler->showPart('foo'));
+        $this->assertSame('blahbarbaz', $this->transpiler->showPart('foo'));
     }
 
     /**
@@ -337,7 +337,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
         $commentNode->addChild(new ExpressionNode('This is my comment'));
         $this->ast->getCurrentNode()
             ->addChild($commentNode);
-        $this->assertEquals(
+        $this->assertSame(
             '<?php /* This is my comment */ ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -351,7 +351,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
         $node = new ExpressionNode('<?php echo "foo"; ?>');
         $this->ast->getCurrentNode()
             ->addChild($node);
-        $this->assertEquals(
+        $this->assertSame(
             '<?php echo "foo"; ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -366,7 +366,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
         $tagNode->addChild(new ExpressionNode('$foo ? "bar" : "baz"'));
         $this->ast->getCurrentNode()
             ->addChild($tagNode);
-        $this->assertEquals(
+        $this->assertSame(
             '<?php echo $__opulenceFortuneTranspiler->sanitize($foo ? "bar" : "baz"); ?>',
             $this->transpiler->transpile($this->view)
         );
@@ -381,7 +381,7 @@ class TranspilerTest extends \PHPUnit\Framework\TestCase
         $tagNode->addChild(new ExpressionNode('$foo ? "bar" : "baz"'));
         $this->ast->getCurrentNode()
             ->addChild($tagNode);
-        $this->assertEquals(
+        $this->assertSame(
             '<?php echo $foo ? "bar" : "baz"; ?>',
             $this->transpiler->transpile($this->view)
         );

--- a/src/Opulence/Views/Tests/Compilers/Fortune/ViewFunctionRegistrantTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Fortune/ViewFunctionRegistrantTest.php
@@ -44,13 +44,13 @@ class ViewFunctionRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testCSSFunction()
     {
         // Test a single value
-        $this->assertEquals(
+        $this->assertSame(
             '<link href="foo" rel="stylesheet">',
             $this->transpiler->callViewFunction('css', 'foo')
         );
 
         // Test multiple values
-        $this->assertEquals(
+        $this->assertSame(
             '<link href="foo" rel="stylesheet">' .
             "\n" .
             '<link href="bar" rel="stylesheet">',
@@ -64,7 +64,7 @@ class ViewFunctionRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testCharsetFunction()
     {
         $charset = 'utf-8';
-        $this->assertEquals(
+        $this->assertSame(
             '<meta charset="' . $charset . '">',
             $this->transpiler->callViewFunction('charset', $charset)
         );
@@ -76,7 +76,7 @@ class ViewFunctionRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testFaviconFunction()
     {
         $path = 'foo';
-        $this->assertEquals(
+        $this->assertSame(
             '<link href="' . $path . '" rel="shortcut icon">',
             $this->transpiler->callViewFunction('favicon', $path)
         );
@@ -89,7 +89,7 @@ class ViewFunctionRegistrantTest extends \PHPUnit\Framework\TestCase
     {
         $name = 'refresh';
         $value = 30;
-        $this->assertEquals(
+        $this->assertSame(
             '<meta http-equiv="' . $name . '" content="' . $value . '">',
             $this->transpiler->callViewFunction('httpEquiv', $name, $value)
         );
@@ -101,7 +101,7 @@ class ViewFunctionRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testHttpMethodInput()
     {
         $httpMethod = 'PUT';
-        $this->assertEquals(
+        $this->assertSame(
             '<input type="hidden" name="_method" value="' . $httpMethod . '">',
             $this->transpiler->callViewFunction('httpMethodInput', $httpMethod)
         );
@@ -113,7 +113,7 @@ class ViewFunctionRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testMetaDescriptionFunction()
     {
         $metaDescription = 'A&W is a root beer';
-        $this->assertEquals(
+        $this->assertSame(
             '<meta name="description" content="' . htmlentities($metaDescription) . '">',
             $this->transpiler->callViewFunction('metaDescription', $metaDescription)
         );
@@ -125,7 +125,7 @@ class ViewFunctionRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testMetaKeywordsFunction()
     {
         $metaKeywords = ['A&W', 'root beer'];
-        $this->assertEquals(
+        $this->assertSame(
             '<meta name="keywords" content="' . implode(',', array_map('htmlentities', $metaKeywords)) . '">',
             $this->transpiler->callViewFunction('metaKeywords', $metaKeywords)
         );
@@ -137,13 +137,13 @@ class ViewFunctionRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testScriptFunction()
     {
         // Test a single value
-        $this->assertEquals(
+        $this->assertSame(
             '<script type="text/javascript" src="foo"></script>',
             $this->transpiler->callViewFunction('script', 'foo')
         );
 
         // Test multiple values
-        $this->assertEquals(
+        $this->assertSame(
             '<script type="text/javascript" src="foo"></script>' .
             PHP_EOL .
             '<script type="text/javascript" src="bar"></script>',
@@ -151,13 +151,13 @@ class ViewFunctionRegistrantTest extends \PHPUnit\Framework\TestCase
         );
 
         // Test a single value with a type
-        $this->assertEquals(
+        $this->assertSame(
             '<script type="text/ecmascript" src="foo"></script>',
             $this->transpiler->callViewFunction('script', 'foo', 'text/ecmascript')
         );
 
         // Test multiple values with a type
-        $this->assertEquals(
+        $this->assertSame(
             '<script type="text/ecmascript" src="foo"></script>' .
             PHP_EOL .
             '<script type="text/ecmascript" src="bar"></script>',
@@ -171,7 +171,7 @@ class ViewFunctionRegistrantTest extends \PHPUnit\Framework\TestCase
     public function testTitleFunction()
     {
         $title = 'A&W';
-        $this->assertEquals(
+        $this->assertSame(
             '<title>' . htmlentities($title) . '</title>',
             $this->transpiler->callViewFunction('pageTitle', $title)
         );

--- a/src/Opulence/Views/Tests/Compilers/Php/PhpCompilerTest.php
+++ b/src/Opulence/Views/Tests/Compilers/Php/PhpCompilerTest.php
@@ -69,7 +69,7 @@ class PhpCompilerTest extends \PHPUnit\Framework\TestCase
             // Don't do anything
         }
 
-        $this->assertEquals($obStartLevel, ob_get_level());
+        $this->assertSame($obStartLevel, ob_get_level());
     }
 
     /**
@@ -85,6 +85,6 @@ class PhpCompilerTest extends \PHPUnit\Framework\TestCase
         $view->expects($this->any())
             ->method('getVars')
             ->willReturn(['foo' => 'Hello', 'bar' => 'world']);
-        $this->assertEquals('Hello, world', $this->compiler->compile($view));
+        $this->assertSame('Hello, world', $this->compiler->compile($view));
     }
 }

--- a/src/Opulence/Views/Tests/Factories/IO/FileViewNameResolverTest.php
+++ b/src/Opulence/Views/Tests/Factories/IO/FileViewNameResolverTest.php
@@ -104,7 +104,7 @@ class FileViewNameResolverTest extends \PHPUnit\Framework\TestCase
     {
         $this->resolver->registerExtension('php');
         $this->resolver->registerPath(self::getTmpFilePath() . '/');
-        $this->assertEquals(self::getTmpFilePath() . '/a.php', $this->resolver->resolve('a'));
+        $this->assertSame(self::getTmpFilePath() . '/a.php', $this->resolver->resolve('a'));
     }
 
     /**
@@ -125,7 +125,7 @@ class FileViewNameResolverTest extends \PHPUnit\Framework\TestCase
     {
         $this->resolver->registerExtension('.php');
         $this->resolver->registerPath(self::getTmpFilePath());
-        $this->assertEquals(self::getTmpFilePath() . '/a.php', $this->resolver->resolve('a'));
+        $this->assertSame(self::getTmpFilePath() . '/a.php', $this->resolver->resolve('a'));
     }
 
     /**
@@ -135,9 +135,9 @@ class FileViewNameResolverTest extends \PHPUnit\Framework\TestCase
     {
         $this->resolver->registerExtension('php');
         $this->resolver->registerPath(self::getTmpFilePath());
-        $this->assertEquals(self::getTmpFilePath() . '/a.php', $this->resolver->resolve('a'));
+        $this->assertSame(self::getTmpFilePath() . '/a.php', $this->resolver->resolve('a'));
         $this->resolver->registerExtension('fortune');
-        $this->assertEquals(self::getTmpFilePath() . '/a.php', $this->resolver->resolve('a'));
+        $this->assertSame(self::getTmpFilePath() . '/a.php', $this->resolver->resolve('a'));
     }
 
     /**
@@ -147,9 +147,9 @@ class FileViewNameResolverTest extends \PHPUnit\Framework\TestCase
     {
         $this->resolver->registerExtension('php');
         $this->resolver->registerPath(self::getTmpFileSubDirPath());
-        $this->assertEquals(self::getTmpFileSubDirPath() . '/a.php', $this->resolver->resolve('a'));
+        $this->assertSame(self::getTmpFileSubDirPath() . '/a.php', $this->resolver->resolve('a'));
         $this->resolver->registerPath(self::getTmpFilePath());
-        $this->assertEquals(self::getTmpFileSubDirPath() . '/a.php', $this->resolver->resolve('a'));
+        $this->assertSame(self::getTmpFileSubDirPath() . '/a.php', $this->resolver->resolve('a'));
     }
 
     /**
@@ -159,9 +159,9 @@ class FileViewNameResolverTest extends \PHPUnit\Framework\TestCase
     {
         $this->resolver->registerExtension('php', 2);
         $this->resolver->registerPath(self::getTmpFilePath());
-        $this->assertEquals(self::getTmpFilePath() . '/a.php', $this->resolver->resolve('a'));
+        $this->assertSame(self::getTmpFilePath() . '/a.php', $this->resolver->resolve('a'));
         $this->resolver->registerExtension('fortune', 1);
-        $this->assertEquals(self::getTmpFilePath() . '/a.fortune', $this->resolver->resolve('a'));
+        $this->assertSame(self::getTmpFilePath() . '/a.fortune', $this->resolver->resolve('a'));
     }
 
     /**
@@ -171,9 +171,9 @@ class FileViewNameResolverTest extends \PHPUnit\Framework\TestCase
     {
         $this->resolver->registerExtension('php');
         $this->resolver->registerPath(self::getTmpFileSubDirPath(), 2);
-        $this->assertEquals(self::getTmpFileSubDirPath() . '/a.php', $this->resolver->resolve('a'));
+        $this->assertSame(self::getTmpFileSubDirPath() . '/a.php', $this->resolver->resolve('a'));
         $this->resolver->registerPath(self::getTmpFilePath(), 1);
-        $this->assertEquals(self::getTmpFilePath() . '/a.php', $this->resolver->resolve('a'));
+        $this->assertSame(self::getTmpFilePath() . '/a.php', $this->resolver->resolve('a'));
     }
 
     /**
@@ -184,7 +184,7 @@ class FileViewNameResolverTest extends \PHPUnit\Framework\TestCase
         $this->resolver->registerExtension('php');
         $this->resolver->registerExtension('fortune');
         $this->resolver->registerPath(self::getTmpFilePath());
-        $this->assertEquals(self::getTmpFilePath() . '/a.fortune', $this->resolver->resolve('a.fortune'));
+        $this->assertSame(self::getTmpFilePath() . '/a.fortune', $this->resolver->resolve('a.fortune'));
     }
 
     /**
@@ -195,6 +195,6 @@ class FileViewNameResolverTest extends \PHPUnit\Framework\TestCase
         $this->resolver->registerExtension('fortune.php');
         $this->resolver->registerExtension('php');
         $this->resolver->registerPath(self::getTmpFilePath());
-        $this->assertEquals(self::getTmpFilePath() . '/a.fortune.php', $this->resolver->resolve('a'));
+        $this->assertSame(self::getTmpFilePath() . '/a.fortune.php', $this->resolver->resolve('a'));
     }
 }

--- a/src/Opulence/Views/Tests/Factories/IO/FileViewReaderTest.php
+++ b/src/Opulence/Views/Tests/Factories/IO/FileViewReaderTest.php
@@ -43,6 +43,6 @@ class FileViewReaderTest extends \PHPUnit\Framework\TestCase
      */
     public function testReadingExistingFile()
     {
-        $this->assertEquals('Foo', $this->reader->read(__DIR__ . '/../../files/Foo.html'));
+        $this->assertSame('Foo', $this->reader->read(__DIR__ . '/../../files/Foo.html'));
     }
 }

--- a/src/Opulence/Views/Tests/Factories/ViewFactoryTest.php
+++ b/src/Opulence/Views/Tests/Factories/ViewFactoryTest.php
@@ -73,7 +73,7 @@ class ViewFactoryTest extends \PHPUnit\Framework\TestCase
             ->method('resolve')
             ->willReturn(__DIR__ . '/../files/TestWithDefaultTagDelimiters.html');
         $view = $this->viewFactory->createView('TestWithDefaultTagDelimiters');
-        $this->assertEquals('bar', $view->getVar('foo'));
+        $this->assertSame('bar', $view->getVar('foo'));
     }
 
     /**
@@ -92,9 +92,9 @@ class ViewFactoryTest extends \PHPUnit\Framework\TestCase
             ->method('resolve')
             ->willReturn(__DIR__ . '/../files/TestWithCustomTagDelimiters.html');
         $view = $this->viewFactory->createView('TestWithDefaultTagDelimiters');
-        $this->assertEquals('bar', $view->getVar('foo'));
+        $this->assertSame('bar', $view->getVar('foo'));
         $view = $this->viewFactory->createView('TestWithCustomTagDelimiters');
-        $this->assertEquals('bar', $view->getVar('foo'));
+        $this->assertSame('bar', $view->getVar('foo'));
     }
 
     /**
@@ -109,7 +109,7 @@ class ViewFactoryTest extends \PHPUnit\Framework\TestCase
             ->method('resolve')
             ->willReturn(__DIR__ . '/../files/TestWithDefaultTagDelimiters.html');
         $view = $this->viewFactory->createView('TestWithDefaultTagDelimiters.html');
-        $this->assertEquals('bar', $view->getVar('foo'));
+        $this->assertSame('bar', $view->getVar('foo'));
     }
 
     /**
@@ -124,7 +124,7 @@ class ViewFactoryTest extends \PHPUnit\Framework\TestCase
             ->method('resolve')
             ->willReturn(__DIR__ . '/../files/TestWithDefaultTagDelimiters.html');
         $view = $this->viewFactory->createView('TestWithDefaultTagDelimiters');
-        $this->assertEquals('bar', $view->getVar('foo'));
+        $this->assertSame('bar', $view->getVar('foo'));
     }
 
     /**
@@ -175,7 +175,7 @@ class ViewFactoryTest extends \PHPUnit\Framework\TestCase
             ->method('resolve')
             ->willReturn(__DIR__ . '/../files/TestWithDefaultTagDelimiters.html');
         $view = $this->viewFactory->createView('TestWithDefaultTagDelimiters.html');
-        $this->assertEquals('bar', $view->getVar('foo'));
+        $this->assertSame('bar', $view->getVar('foo'));
     }
 
     /**
@@ -192,7 +192,7 @@ class ViewFactoryTest extends \PHPUnit\Framework\TestCase
             ->method('resolve')
             ->willReturn(__DIR__ . '/../files/TestWithDefaultTagDelimiters.html');
         $view = $this->viewFactory->createView('TestWithDefaultTagDelimiters');
-        $this->assertEquals('bar', $view->getVar('foo'));
+        $this->assertSame('bar', $view->getVar('foo'));
     }
 
     /**
@@ -210,7 +210,7 @@ class ViewFactoryTest extends \PHPUnit\Framework\TestCase
             ->method('resolve')
             ->willReturn(__DIR__ . '/../files/TestWithDefaultTagDelimiters.html');
         $view = $this->viewFactory->createView('TestWithDefaultTagDelimiters');
-        $this->assertEquals('bar', $view->getVar('foo'));
-        $this->assertEquals('baz', $view->getVar('bar'));
+        $this->assertSame('bar', $view->getVar('foo'));
+        $this->assertSame('baz', $view->getVar('bar'));
     }
 }

--- a/src/Opulence/Views/Tests/ViewTest.php
+++ b/src/Opulence/Views/Tests/ViewTest.php
@@ -44,8 +44,8 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     public function testGettingCommentDelimiters()
     {
         $directiveDelimiters = $this->view->getDelimiters(View::DELIMITER_TYPE_COMMENT);
-        $this->assertEquals(View::DEFAULT_OPEN_COMMENT_DELIMITER, $directiveDelimiters[0]);
-        $this->assertEquals(View::DEFAULT_CLOSE_COMMENT_DELIMITER, $directiveDelimiters[1]);
+        $this->assertSame(View::DEFAULT_OPEN_COMMENT_DELIMITER, $directiveDelimiters[0]);
+        $this->assertSame(View::DEFAULT_CLOSE_COMMENT_DELIMITER, $directiveDelimiters[1]);
         $this->view->setDelimiters(View::DELIMITER_TYPE_COMMENT, ['foo', 'bar']);
         $this->assertEquals(['foo', 'bar'], $this->view->getDelimiters(View::DELIMITER_TYPE_COMMENT));
     }
@@ -64,8 +64,8 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     public function testGettingDirectiveDelimiters()
     {
         $directiveDelimiters = $this->view->getDelimiters(View::DELIMITER_TYPE_DIRECTIVE);
-        $this->assertEquals(View::DEFAULT_OPEN_DIRECTIVE_DELIMITER, $directiveDelimiters[0]);
-        $this->assertEquals(View::DEFAULT_CLOSE_DIRECTIVE_DELIMITER, $directiveDelimiters[1]);
+        $this->assertSame(View::DEFAULT_OPEN_DIRECTIVE_DELIMITER, $directiveDelimiters[0]);
+        $this->assertSame(View::DEFAULT_CLOSE_DIRECTIVE_DELIMITER, $directiveDelimiters[1]);
         $this->view->setDelimiters(View::DELIMITER_TYPE_DIRECTIVE, ['foo', 'bar']);
         $this->assertEquals(['foo', 'bar'], $this->view->getDelimiters(View::DELIMITER_TYPE_DIRECTIVE));
     }
@@ -84,12 +84,12 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     public function testGettingSanitizedTagDelimiters()
     {
         $sanitizedDelimiters = $this->view->getDelimiters(View::DELIMITER_TYPE_SANITIZED_TAG);
-        $this->assertEquals(View::DEFAULT_OPEN_SANITIZED_TAG_DELIMITER, $sanitizedDelimiters[0]);
-        $this->assertEquals(View::DEFAULT_CLOSE_SANITIZED_TAG_DELIMITER, $sanitizedDelimiters[1]);
+        $this->assertSame(View::DEFAULT_OPEN_SANITIZED_TAG_DELIMITER, $sanitizedDelimiters[0]);
+        $this->assertSame(View::DEFAULT_CLOSE_SANITIZED_TAG_DELIMITER, $sanitizedDelimiters[1]);
         $this->view->setDelimiters(View::DELIMITER_TYPE_SANITIZED_TAG, ['foo', 'bar']);
         $sanitizedDelimiters = $this->view->getDelimiters(View::DELIMITER_TYPE_SANITIZED_TAG);
-        $this->assertEquals('foo', $sanitizedDelimiters[0]);
-        $this->assertEquals('bar', $sanitizedDelimiters[1]);
+        $this->assertSame('foo', $sanitizedDelimiters[0]);
+        $this->assertSame('bar', $sanitizedDelimiters[1]);
     }
 
     /**
@@ -98,8 +98,8 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     public function testGettingUnsanitizedTagDelimiters()
     {
         $unsanitizedTagDelimiters = $this->view->getDelimiters(View::DELIMITER_TYPE_UNSANITIZED_TAG);
-        $this->assertEquals(View::DEFAULT_OPEN_UNSANITIZED_TAG_DELIMITER, $unsanitizedTagDelimiters[0]);
-        $this->assertEquals(View::DEFAULT_CLOSE_UNSANITIZED_TAG_DELIMITER, $unsanitizedTagDelimiters[1]);
+        $this->assertSame(View::DEFAULT_OPEN_UNSANITIZED_TAG_DELIMITER, $unsanitizedTagDelimiters[0]);
+        $this->assertSame(View::DEFAULT_CLOSE_UNSANITIZED_TAG_DELIMITER, $unsanitizedTagDelimiters[1]);
         $this->view->setDelimiters(View::DELIMITER_TYPE_UNSANITIZED_TAG, ['foo', 'bar']);
         $this->assertEquals(['foo', 'bar'], $this->view->getDelimiters(View::DELIMITER_TYPE_UNSANITIZED_TAG));
     }
@@ -110,7 +110,7 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     public function testGettingVar()
     {
         $this->view->setVar('foo', 'bar');
-        $this->assertEquals('bar', $this->view->getVar('foo'));
+        $this->assertSame('bar', $this->view->getVar('foo'));
     }
 
     /**
@@ -150,7 +150,7 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     public function testSettingContents()
     {
         $this->view->setContents('blah');
-        $this->assertEquals('blah', $this->view->getContents());
+        $this->assertSame('blah', $this->view->getContents());
     }
 
     /**
@@ -159,7 +159,7 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     public function testSettingContentsInConstructor()
     {
         $view = new View('foo', 'bar');
-        $this->assertEquals('bar', $view->getContents());
+        $this->assertSame('bar', $view->getContents());
     }
 
     /**
@@ -190,7 +190,7 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     public function testSettingPathInConstructor()
     {
         $view = new View('foo');
-        $this->assertEquals('foo', $view->getPath());
+        $this->assertSame('foo', $view->getPath());
     }
 
     /**
@@ -199,7 +199,7 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     public function testSettingPathInSetter()
     {
         $this->view->setPath('foo');
-        $this->assertEquals('foo', $this->view->getPath());
+        $this->assertSame('foo', $this->view->getPath());
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assert value equals stict.
- Using the `assertIsString` to make assertion types clear.
- Using the `assertArrayNotHasKey` to assert specific key is not existed on array.