### PR TITLE
Allow using psr-log 2.0 and 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "ext-openssl": "*",
     "ext-mbstring": "*",
     "opis/closure": "~3.6",
-    "psr/log": "~1.0"
+    "psr/log": "~1.0 || ^2.0 || ^3.0"
   },
   "require-dev": {
     "ext-pdo": "*",


### PR DESCRIPTION
these two versions are required by some libraries, they only differ from 1.1.14 in better supporting later PHP versions.

v2: https://github.com/php-fig/log/pull/76
v3: https://github.com/php-fig/log/pull/77